### PR TITLE
Update util/mirror-tarballs

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -27,7 +27,7 @@ cd nginx-$ver || exit 1
 # patch the patch
 
 cp $root/patches/nginx-$main_ver-server_header.patch server_header.patch || exit 1
-sed -i $"s/NGINX_VERSION \".unknown\"/NGINX_VERSION \".$minor_ver\"/" \
+sed -i '' $"s/NGINX_VERSION \".unknown\"/NGINX_VERSION \".$minor_ver\"/" \
     server_header.patch || exit 1
 
 patch -p2 < server_header.patch || exit 1
@@ -61,7 +61,7 @@ rm -f *.patch || exit 1
 cd .. || exit 1
 
 cp $root/patches/nginx-$main_ver-no_pool.patch ./nginx-no_pool.patch || exit 1
-sed -i $"s/NGINX_VERSION \".unknown/NGINX_VERSION \".$minor_ver/" \
+sed -i '' $"s/NGINX_VERSION \".unknown/NGINX_VERSION \".$minor_ver/" \
     ./nginx-no_pool.patch || exit 1
 rm -rf no-pool-nginx-$ver
 


### PR DESCRIPTION
fix osx lion/darwin sed issue. (sed -i should follow a zero-length extension).
