### PR TITLE
[util/resty] force config file path

### DIFF
--- a/util/resty
+++ b/util/resty
@@ -251,7 +251,7 @@ _EOC_
 
 close $out;
 
-my $cmd = "$nginx_path -p $prefix_dir/";
+my $cmd = "$nginx_path -p $prefix_dir/ -c $conf_file";
 
 my $child_pid;
 


### PR DESCRIPTION
some nginx configurations can have different config path compiled in and will load it when not forced

fixes one issue described in https://groups.google.com/forum/#!topic/openresty-en/ViVMIlNCqws
