### PR TITLE
feature: applied the safe_resolver_ipv6_option patch 

### DIFF
--- a/patches/nginx-1.11.2-safe_resolver_ipv6_option.patch
+++ b/patches/nginx-1.11.2-safe_resolver_ipv6_option.patch
@@ -1,0 +1,55 @@
+# HG changeset patch
+# User Thibault Charbonnier <thibaultcha@fastmail.com>
+# Date 1481847421 28800
+#      Thu Dec 15 16:17:01 2016 -0800
+# Node ID 8bf038fe006fd8ae253d6b41fc6cf109a8912d3e
+# Parent  a3dc657f4e9530623683e6b85bd7492662e4dc47
+Resolver: ignore ipv6=off resolver option when no ipv6 support
+
+Makes the resolver directive more robust: we only error out when ipv6
+resolution is desired but not supported (ipv6=on).
+
+use case 1: some configurations are sometimes re-used between builds with and
+without ipv6 support. This patch avoids the need to remove the "ipv6=off" flag.
+
+use case 2: currently, some tools rely on the --with-ipv6 configure option from
+"nginx -V" to determine if ipv6 resolution should be disabled in some cases.
+With this option disappearing in Nginx 1.11.5, this patch would allow such tools
+to assume "ipv6=off" to be safe regardless of ipv6 support in the current
+build.
+
+diff -r a3dc657f4e95 -r 8bf038fe006f src/core/ngx_resolver.c
+--- a/src/core/ngx_resolver.c	Thu Dec 15 21:44:34 2016 +0300
++++ b/src/core/ngx_resolver.c	Thu Dec 15 16:17:01 2016 -0800
+@@ -224,14 +224,22 @@
+             continue;
+         }
+ 
+-#if (NGX_HAVE_INET6)
+         if (ngx_strncmp(names[i].data, "ipv6=", 5) == 0) {
+ 
+             if (ngx_strcmp(&names[i].data[5], "on") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 1;
++#else
++                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                   "no ipv6 support but \"%V\" in resolver",
++                                   &names[i]);
++                return NULL;
++#endif
+ 
+             } else if (ngx_strcmp(&names[i].data[5], "off") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 0;
++#endif
+ 
+             } else {
+                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+@@ -241,7 +249,6 @@
+ 
+             continue;
+         }
+-#endif
+ 
+         ngx_memzero(&u, sizeof(ngx_url_t));
+ 

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -333,6 +333,10 @@ echo "$info_txt applying the upstream_timeout_fields patch for nginx"
 patch -p1 < $root/patches/nginx-$main_ver-upstream_timeout_fields.patch || exit 1
 echo
 
+echo "$info_txt applying the safe_resolver_ipv6_option patch for nginx"
+patch -p1 < $root/patches/nginx-$main_ver-safe_resolver_ipv6_option.patch || exit 1
+echo
+
 cp $root/html/index.html docs/html/ || exit 1
 cp $root/html/50x.html docs/html/ || exit 1
 


### PR DESCRIPTION
As discussed in openresty/resty-cli#20, this patch to the nginx core provides a failsafe when the `ipv6=off` option is given in the `resolver` directive while nginx is not built with IPv6 support. It also provides a somewhat nicer message when `ipv6=on` without support for IPv6.

I tested this on my side with the `util/mirror-tarballs` utility and then installing the given tarball, everything seemed ok. Let me know if anything else is missing!