### PR TITLE
optimization: reduce the number of ngx_connection_t allocated inside the

### DIFF
--- a/patches/nginx-1.11.2-privileged_agent_process.patch
+++ b/patches/nginx-1.11.2-privileged_agent_process.patch
@@ -41,7 +41,7 @@ index c51b7ff..3261f90 100644
      ngx_msec_t                timer_resolution;
  
 diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
-index 3ead164..2b3f8df 100644
+index 7cee1c5..c4f70d6 100644
 --- a/src/os/unix/ngx_process_cycle.c
 +++ b/src/os/unix/ngx_process_cycle.c
 @@ -15,6 +15,8 @@ static void ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n,
@@ -149,7 +149,7 @@ index 3ead164..2b3f8df 100644
          if (setgid(ccf->group) == -1) {
              ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno,
                            "setgid(%d) failed", ccf->group);
-@@ -1144,6 +1184,44 @@ ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data)
+@@ -1144,6 +1184,47 @@ ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data)
  
  
  static void
@@ -165,6 +165,9 @@ index 3ead164..2b3f8df 100644
 +    ngx_is_privileged_agent = 1;
 +
 +    ngx_close_listening_sockets(cycle);
++
++    /* Set a moderate number of connections for a helper process. */
++    cycle->connection_n = 512;
 +
 +    ngx_worker_process_init(cycle, -1);
 +


### PR DESCRIPTION
privileged worker to avoid excessive memory consumption when
`worker_connections` is set very high.

When `worker_connections` is set to  `409600`. on x64 machine:

Before:
```
root      66953  0.0  8.9 519876 180556 ?       S    16:26   0:00 nginx: privileged agent process
```

After:
```
root      67955  0.0  0.5 350332 11100 ?        S    16:31   0:00 nginx: privileged agent process
```