### PR TITLE
feature: make $proxy_add_x_forwarded_for accessible in Lua land.

### DIFF
--- a/patches/nginx-1.11.2-proxy_host_port_vars.patch
+++ b/patches/nginx-1.11.2-proxy_host_port_vars.patch
@@ -1,6 +1,6 @@
---- nginx-1.11.2/src/http/modules/ngx_http_proxy_module.c	2013-10-08 05:07:14.000000000 -0700
-+++ nginx-1.11.2-patched/src/http/modules/ngx_http_proxy_module.c	2013-10-27 15:29:41.619378592 -0700
-@@ -602,10 +602,10 @@ static ngx_keyval_t  ngx_http_proxy_cach
+--- nginx-1.11.2/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
++++ nginx-1.11.2-patched/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
+@@ -793,13 +793,13 @@ static ngx_keyval_t  ngx_http_proxy_cach
  static ngx_http_variable_t  ngx_http_proxy_vars[] = {
  
      { ngx_string("proxy_host"), NULL, ngx_http_proxy_host_variable, 0,
@@ -12,4 +12,8 @@
 +      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
  
      { ngx_string("proxy_add_x_forwarded_for"), NULL,
-       ngx_http_proxy_add_x_forwarded_for_variable, 0, NGX_HTTP_VAR_NOHASH, 0 },
+-      ngx_http_proxy_add_x_forwarded_for_variable, 0, NGX_HTTP_VAR_NOHASH, 0 },
++      ngx_http_proxy_add_x_forwarded_for_variable, 0, 0, 0 },
+ 
+ #if 0
+     { ngx_string("proxy_add_via"), NULL, NULL, 0, NGX_HTTP_VAR_NOHASH, 0 },


### PR DESCRIPTION
This modification make `$proxy_add_x_forwarded_for` accessible via `ngx.var`, just like what have been done with `$proxy_host` and `$proxy_port`.
 
Patch originally discussed at https://github.com/openresty/lua-nginx-module/issues/1115

Looking forward for any feedback.