### PR TITLE
patches: ensure "server" header in HTTP/2 response shows "openresty"

### DIFF
--- a/patches/nginx-1.11.2-server_header.patch
+++ b/patches/nginx-1.11.2-server_header.patch
@@ -1,19 +1,21 @@
-diff -ur nginx-1.11.2/src/core/nginx.h nginx-1.11.2-patched/src/core/nginx.h
---- nginx-1.11.2/src/core/nginx.h	2010-02-12 17:31:01.000000000 +0800
-+++ nginx-1.11.2-patched/src/core/nginx.h	2010-03-30 10:52:13.240702627 +0800
-@@ -10,7 +10,7 @@
+diff --git a/src/core/nginx.h b/src/core/nginx.h
+index 75a4a40..ed4f104 100644
+--- a/src/core/nginx.h
++++ b/src/core/nginx.h
+@@ -11,7 +11,7 @@
  
- #define nginx_version         1011002
+ #define nginx_version      1011002
  #define NGINX_VERSION      "1.11.2"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "openresty/" NGINX_VERSION ".unknown"
  
- #define NGINX_VAR          "NGINX"
- #define NGX_OLDPID_EXT     ".oldbin"
-diff -ur nginx-1.11.2/src/http/ngx_http_header_filter_module.c nginx-1.11.2-patched/src/http/ngx_http_header_filter_module.c
---- nginx-1.11.2/src/http/ngx_http_header_filter_module.c	2010-03-03 23:14:04.000000000 +0800
-+++ nginx-1.11.2-patched/src/http/ngx_http_header_filter_module.c	2010-03-30 10:52:53.670909405 +0800
-@@ -45,7 +45,7 @@
+ #ifdef NGX_BUILD
+ #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
+diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
+index f000b2e..5882a66 100644
+--- a/src/http/ngx_http_header_filter_module.c
++++ b/src/http/ngx_http_header_filter_module.c
+@@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
  };
  
  
@@ -22,3 +24,16 @@ diff -ur nginx-1.11.2/src/http/ngx_http_header_filter_module.c nginx-1.11.2-patc
  static char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
  
  
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 39ff103..0dc3924 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -139,7 +139,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     ngx_http_core_srv_conf_t  *cscf;
+     u_char                     addr[NGX_SOCKADDR_STRLEN];
+ 
+-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
++    static const u_char nginx[8] = "\x87\x3d\x65\xaa\xc2\xa1\x3e\xbf";
+ #if (NGX_HTTP_GZIP)
+     static const u_char accept_encoding[12] =
+         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";

--- a/patches/nginx-1.13.3-server_header.patch
+++ b/patches/nginx-1.13.3-server_header.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/nginx.h b/src/core/nginx.h
-index 37e257fc..fd49eff7 100644
+index 1f3a369..3620509 100644
 --- a/src/core/nginx.h
 +++ b/src/core/nginx.h
 @@ -11,7 +11,7 @@
@@ -12,7 +12,7 @@ index 37e257fc..fd49eff7 100644
  #ifdef NGX_BUILD
  #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
 diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
-index 9b894059..ca13f2a3 100644
+index 9b89405..ca13f2a 100644
 --- a/src/http/ngx_http_header_filter_module.c
 +++ b/src/http/ngx_http_header_filter_module.c
 @@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
@@ -24,3 +24,16 @@ index 9b894059..ca13f2a3 100644
  static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
  static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
  
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 8621e7a..a76c677 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -143,7 +143,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     ngx_http_core_srv_conf_t  *cscf;
+     u_char                     addr[NGX_SOCKADDR_STRLEN];
+ 
+-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
++    static const u_char nginx[8] = "\x87\x3d\x65\xaa\xc2\xa1\x3e\xbf";
+ #if (NGX_HTTP_GZIP)
+     static const u_char accept_encoding[12] =
+         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";

--- a/patches/nginx-1.13.4-server_header.patch
+++ b/patches/nginx-1.13.4-server_header.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/nginx.h b/src/core/nginx.h
-index 37e257fc..fd49eff7 100644
+index 3649945..ddc1d95 100644
 --- a/src/core/nginx.h
 +++ b/src/core/nginx.h
 @@ -11,7 +11,7 @@
@@ -12,7 +12,7 @@ index 37e257fc..fd49eff7 100644
  #ifdef NGX_BUILD
  #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
 diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
-index 9b894059..ca13f2a3 100644
+index 9b89405..ca13f2a 100644
 --- a/src/http/ngx_http_header_filter_module.c
 +++ b/src/http/ngx_http_header_filter_module.c
 @@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
@@ -24,3 +24,16 @@ index 9b894059..ca13f2a3 100644
  static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
  static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
  
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 8621e7a..a76c677 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -143,7 +143,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     ngx_http_core_srv_conf_t  *cscf;
+     u_char                     addr[NGX_SOCKADDR_STRLEN];
+ 
+-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
++    static const u_char nginx[8] = "\x87\x3d\x65\xaa\xc2\xa1\x3e\xbf";
+ #if (NGX_HTTP_GZIP)
+     static const u_char accept_encoding[12] =
+         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";

--- a/patches/nginx-1.13.5-server_header.patch
+++ b/patches/nginx-1.13.5-server_header.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/nginx.h b/src/core/nginx.h
-index 37e257fc..fd49eff7 100644
+index a3c0ef8..1263881 100644
 --- a/src/core/nginx.h
 +++ b/src/core/nginx.h
 @@ -11,7 +11,7 @@
@@ -12,7 +12,7 @@ index 37e257fc..fd49eff7 100644
  #ifdef NGX_BUILD
  #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
 diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
-index 9b894059..ca13f2a3 100644
+index 9b89405..ca13f2a 100644
 --- a/src/http/ngx_http_header_filter_module.c
 +++ b/src/http/ngx_http_header_filter_module.c
 @@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
@@ -24,3 +24,16 @@ index 9b894059..ca13f2a3 100644
  static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
  static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
  
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 8621e7a..a76c677 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -143,7 +143,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     ngx_http_core_srv_conf_t  *cscf;
+     u_char                     addr[NGX_SOCKADDR_STRLEN];
+ 
+-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
++    static const u_char nginx[8] = "\x87\x3d\x65\xaa\xc2\xa1\x3e\xbf";
+ #if (NGX_HTTP_GZIP)
+     static const u_char accept_encoding[12] =
+         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";


### PR DESCRIPTION
when server_tokens are turned off.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
