### PR TITLE
change: remove old Makefile right before generating new one

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -23,10 +23,6 @@ my $OS = $^O;
 
 my $ngx_dir;
 
-if (-f 'Makefile') {
-    unlink 'Makefile' or die "ERROR: failed to remove existing Makefile: $!\n";
-}
-
 for my $opt (@ARGV) {
     if ($opt =~ /^--platform=(.*)/) {
         $OS = $1;
@@ -1368,6 +1364,11 @@ _EOC_
 }
 
 sub gen_makefile {
+    if (-f 'Makefile') {
+        unlink 'Makefile' or
+            die "ERROR: failed to remove existing Makefile: $!\n";
+    }
+
     open my $out, ">Makefile" or
         die "Cannot open Makefile for writing: $!\n";
 


### PR DESCRIPTION
This change avoid remove Makefile unexpectedly when we run `./configure
--help`.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
