### PR TITLE
patch: updated stream_proxy_timeout_fields patch to work with 1.13.8.

### DIFF
--- a/patches/nginx-1.13.8-stream_proxy_timeout_fields.patch
+++ b/patches/nginx-1.13.8-stream_proxy_timeout_fields.patch
@@ -1,5 +1,5 @@
 diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
-index 09d2459..a4dda5d 100644
+index 09d24593..a4dda5da 100644
 --- a/src/stream/ngx_stream.h
 +++ b/src/stream/ngx_stream.h
 @@ -241,6 +241,15 @@ typedef struct {
@@ -27,7 +27,7 @@ index 09d2459..a4dda5d 100644
  
  typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
 diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
-index 0afde1c..c16db76 100644
+index 818d7329..32bfd79f 100644
 --- a/src/stream/ngx_stream_proxy_module.c
 +++ b/src/stream/ngx_stream_proxy_module.c
 @@ -359,6 +359,7 @@ ngx_stream_proxy_handler(ngx_stream_session_t *s)
@@ -124,7 +124,7 @@ index 0afde1c..c16db76 100644
          }
  
          pc->ssl->handler = ngx_stream_proxy_ssl_handshake;
-@@ -1285,11 +1303,14 @@ ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
+@@ -1285,6 +1303,7 @@ ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
      ngx_stream_session_t         *s;
      ngx_stream_upstream_t        *u;
      ngx_stream_proxy_srv_conf_t  *pscf;
@@ -132,14 +132,16 @@ index 0afde1c..c16db76 100644
  
      c = ev->data;
      s = c->data;
-     u = s->upstream;
+@@ -1296,6 +1315,8 @@ ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
+         return;
+     }
  
 +    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
 +
      c = s->connection;
      pc = u->peer.connection;
  
-@@ -1309,7 +1330,7 @@ ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
+@@ -1315,7 +1336,7 @@ ngx_stream_proxy_process_connection(ngx_event_t *ev, ngx_uint_t from_upstream)
                  }
  
                  if (u->connected && !c->read->delayed && !pc->read->delayed) {
@@ -148,7 +150,7 @@ index 0afde1c..c16db76 100644
                  }
  
                  return;
-@@ -1451,6 +1472,9 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
+@@ -1461,6 +1482,9 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
      ngx_log_handler_pt            handler;
      ngx_stream_upstream_t        *u;
      ngx_stream_proxy_srv_conf_t  *pscf;
@@ -158,7 +160,7 @@ index 0afde1c..c16db76 100644
  
      u = s->upstream;
  
-@@ -1642,7 +1666,7 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
+@@ -1652,7 +1676,7 @@ ngx_stream_proxy_process(ngx_stream_session_t *s, ngx_uint_t from_upstream,
          }
  
          if (!c->read->delayed && !pc->read->delayed) {


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
