### PR TITLE
patches: added patches to make sure ngx_stream_ssl_preread_module will

### DIFF
--- a/patches/nginx-1.13.6-stream_ssl_preread_no_skip.patch
+++ b/patches/nginx-1.13.6-stream_ssl_preread_no_skip.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stream/ngx_stream_ssl_preread_module.c b/src/stream/ngx_stream_ssl_preread_module.c
+index e3d11fd9..3717b5fe 100644
+--- a/src/stream/ngx_stream_ssl_preread_module.c
++++ b/src/stream/ngx_stream_ssl_preread_module.c
+@@ -159,7 +159,7 @@ ngx_stream_ssl_preread_handler(ngx_stream_session_t *s)
+ 
+         rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+         if (rc != NGX_AGAIN) {
+-            return rc;
++            return rc == NGX_OK ? NGX_DECLINED : rc;
+         }
+ 
+         p += len;

--- a/patches/nginx-1.13.8-stream_ssl_preread_no_skip.patch
+++ b/patches/nginx-1.13.8-stream_ssl_preread_no_skip.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stream/ngx_stream_ssl_preread_module.c b/src/stream/ngx_stream_ssl_preread_module.c
+index e3d11fd9..3717b5fe 100644
+--- a/src/stream/ngx_stream_ssl_preread_module.c
++++ b/src/stream/ngx_stream_ssl_preread_module.c
+@@ -159,7 +159,7 @@ ngx_stream_ssl_preread_handler(ngx_stream_session_t *s)
+ 
+         rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+         if (rc != NGX_AGAIN) {
+-            return rc;
++            return rc == NGX_OK ? NGX_DECLINED : rc;
+         }
+ 
+         p += len;

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -56,6 +56,13 @@ if [ "$answer" = "Y" ]; then
     echo
 fi
 
+answer=`$root/util/ver-ge "$main_ver" 1.13.6`
+if [ "$answer" = "Y" ]; then
+    echo "$info_txt applying the stream_ssl_preread_no_skip patch for nginx"
+    patch -p1 < $root/patches/nginx-$main_ver-stream_ssl_preread_no_skip.patch || exit 1
+    echo
+fi
+
 answer=`$root/util/ver-ge "$main_ver" 1.5.12`
 if [ "$answer" = "N" ]; then
     echo "$info_txt applying the patch for nginx security advisory (CVE-2014-0133)"


### PR DESCRIPTION
not skip the rest of the preread phase when SNI server name parsing was
successful.

Otherwise when `ngx_stream_ssl_preread_module` runs successfully, `preread_by_lua*` will be skipped.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
