### PR TITLE
fix bugs: when --with-cc-opt=OPTS assigned, "-O2" not be overridden

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -232,6 +232,7 @@ for my $opt (@ARGV) {
         usage 0;
 
     } elsif ($opt =~ /^--with-cc-opt=(.*)/) {
+        shift @ngx_cc_opts；
         push @ngx_cc_opts, $1;
 
     } elsif ($opt =~ /^--with-ld-opt=(.*)/) {


### PR DESCRIPTION
in configure, shift ngx_cc_opts when --with-cc-opt= assigned

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
