### PR TITLE
feature: use resolv.conf from local machine as core resolvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ upload-win32
 html_out/
 TODO
 doc/LuaJIT-2.1/changes.pod
+t/servroot

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..9156fadd 100644
+index cd55520c..d8dc49e8 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
 @@ -5,6 +5,7 @@
@@ -39,7 +39,7 @@ index cd55520c..9156fadd 100644
 +    ngx_file_t                       file;
 +    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
 +    u_char                           ipv6_buf[NGX_INET6_ADDRSTRLEN];
-+    ngx_uint_t                       address, j, total = 0;
++    ngx_uint_t                       address = 0, j, total = 0;
 +    ssize_t                          n, i;
 +    enum {
 +        sw_nameserver,

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..6a3f98bb 100644
+index cd55520c..d91c406c 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
 @@ -5,6 +5,7 @@
@@ -25,28 +25,31 @@ index cd55520c..6a3f98bb 100644
  
  typedef struct {
      u_char  ident_hi;
-@@ -131,6 +140,138 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+@@ -131,6 +140,180 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
  #endif
  
  
 +static ngx_int_t
-+ngx_resolver_read_resolv_conf(ngx_conf_t *cf, ngx_resolver_t *r, u_char *path)
++ngx_resolver_read_resolv_conf(ngx_conf_t *cf, ngx_resolver_t *r, u_char *path,
++    size_t path_len)
 +{
 +    ngx_url_t                        u;
 +    ngx_resolver_connection_t       *rec;
 +    ngx_fd_t                         fd;
 +    ngx_file_t                       file;
 +    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
++    u_char                           ipv6_buf[NGX_INET6_ADDRSTRLEN];
 +    ngx_uint_t                       address, j, total = 0;
 +    ssize_t                          n, i;
 +    enum {
 +        sw_nameserver,
++        sw_spaces,
 +        sw_address,
 +        sw_skip
 +    } state;
 +
 +    file.name.data = path;
-+    file.name.len = ngx_strlen(path);
++    file.name.len = path_len;
 +
 +    if (ngx_conf_full_name(cf->cycle, &file.name, 1) != NGX_OK) {
 +        return NGX_ERROR;
@@ -71,6 +74,11 @@ index cd55520c..6a3f98bb 100644
 +
 +    n = ngx_read_file(&file, buf, NGX_RESOLVER_FILE_BUF_SIZE, 0);
 +
++    if (n == NGX_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_read_file_n " \"%s\" failed", file.name.data);
++    }
++
 +    if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
 +        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
 +                           ngx_close_file_n " \"%s\" failed", file.name.data);
@@ -93,15 +101,22 @@ index cd55520c..6a3f98bb 100644
 +
 +        case sw_nameserver:
 +
-+            if ((size_t) n - i >= sizeof("nameserver ") - 1
-+                && ngx_memcmp(buf + i, "nameserver ",
-+                              sizeof("nameserver ") - 1) == 0)
++            if ((size_t) n - i >= sizeof("nameserver") - 1
++                && ngx_memcmp(buf + i, "nameserver",
++                              sizeof("nameserver") - 1) == 0)
 +            {
-+                state = sw_address;
-+                i += sizeof("nameserver ") - 1;
-+                address = i;
++                state = sw_spaces;
++                i += sizeof("nameserver") - 1;
 +
 +                continue;
++            }
++
++            break;
++
++        case sw_spaces:
++            if (buf[i] != '\t' && buf[i] != ' ') {
++                address = i;
++                state = sw_address;
 +            }
 +
 +            break;
@@ -112,8 +127,26 @@ index cd55520c..6a3f98bb 100644
 +                ngx_memzero(&u, sizeof(ngx_url_t));
 +
 +                u.url.data = buf + address;
-+                u.url.len = i - address;
++                u.url.len = i == n - 1 ? n - address : i - address;
 +                u.default_port = 53;
++
++                /* IPv6? */
++                if (ngx_strlchr(u.url.data, u.url.data + u.url.len, ':') != NULL) {
++                    if (u.url.len + 2 > sizeof(ipv6_buf)) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "IPv6 resolver address is too long: \"%V\"",
++                                           &u.url);
++
++                        return NGX_ERROR;
++                    }
++
++                    ipv6_buf[0] = '[';
++                    ngx_memcpy(ipv6_buf + 1, u.url.data, u.url.len);
++                    ipv6_buf[u.url.len + 1] = ']';
++
++                    u.url.data = ipv6_buf;
++                    u.url.len = u.url.len + 2;
++                }
 +
 +                if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
 +                    if (u.err) {
@@ -141,6 +174,15 @@ index cd55520c..6a3f98bb 100644
 +
 +                total++;
 +
++#if (NGX_DEBUG)
++                /*
++                 * logs with level below NGX_LOG_NOTICE will not be printed
++                 * in this early phase
++                 */
++                ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
++                                   "parsed a resolver: \"%V\"", &u.url);
++#endif
++
 +                state = sw_nameserver;
 +            }
 +
@@ -164,7 +206,7 @@ index cd55520c..6a3f98bb 100644
  ngx_resolver_t *
  ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
  {
-@@ -246,6 +387,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+@@ -246,6 +429,35 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
          }
  #endif
  
@@ -172,7 +214,8 @@ index cd55520c..6a3f98bb 100644
 +
 +            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
 +                if (ngx_resolver_read_resolv_conf(cf, r,
-+                                                  (u_char *) NGX_RESOLVER_FILE_NAME)
++                                                  (u_char *) NGX_RESOLVER_FILE_NAME,
++                                                  sizeof(NGX_RESOLVER_FILE_NAME) - 1)
 +                    != NGX_OK)
 +                {
 +                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -182,7 +225,8 @@ index cd55520c..6a3f98bb 100644
 +
 +            } else if (ngx_strcmp(&names[i].data[6], "off") != 0) {
 +                if (ngx_resolver_read_resolv_conf(cf, r,
-+                                                  &names[i].data[6])
++                                                  &names[i].data[6],
++                                                  names[i].len - 6)
 +                    != NGX_OK)
 +                {
 +                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,0 +1,192 @@
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index cd55520c..06d1c461 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -15,6 +15,9 @@
+ #define NGX_RESOLVER_TCP_RSIZE  (2 + 65535)
+ #define NGX_RESOLVER_TCP_WSIZE  8192
+ 
++#define NGX_RESOLVER_FILE_BUF_SIZE  2048
++#define NGX_RESOLVER_FILE_NAME      "/etc/resolv.conf"
++
+ 
+ typedef struct {
+     u_char  ident_hi;
+@@ -131,6 +134,143 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+ #endif
+ 
+ 
++static ngx_int_t
++ngx_resolver_read_resolv_conf(ngx_conf_t *cf, ngx_resolver_t *r, u_char *path)
++{
++    ngx_url_t                        u;
++    ngx_resolver_connection_t       *rec;
++    ngx_fd_t                         fd;
++    ngx_file_t                       file;
++    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
++    ngx_uint_t                       address, j;
++    ssize_t                          n, i;
++    enum {
++        sw_nameserver,
++        sw_address,
++        sw_skip
++    } state;
++
++    file.name.data = path;
++    file.name.len = ngx_strlen(path);
++
++    if (ngx_conf_full_name(cf->cycle, &file.name, 1) != NGX_OK) {
++        return NGX_ERROR;
++    }
++
++    fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,
++                       NGX_FILE_OPEN, 0);
++
++    if (fd == NGX_INVALID_FILE) {
++        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
++                           ngx_open_file_n " \"%s\" failed", file.name.data);
++
++        return NGX_ERROR;
++    }
++
++    ngx_memzero(&file, sizeof(ngx_file_t));
++
++    file.fd = fd;
++    file.name.data = path;
++    file.name.len = ngx_strlen(path) - 1;
++    file.log = cf->log;
++
++    state = sw_nameserver;
++
++    n = ngx_read_file(&file, buf, NGX_RESOLVER_FILE_BUF_SIZE, 0);
++
++    if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_close_file_n " \"%s\" failed", file.name.data);
++    }
++
++    if (n == NGX_ERROR) {
++        return NGX_ERROR;
++    }
++
++    if (n == 0) {
++        return NGX_OK;
++    }
++
++    for (i = 0; i < n; /* void */) {
++        if (buf[i] == '#' || buf[i] == ';') {
++            state = sw_skip;
++        }
++
++        switch (state) {
++
++        case sw_nameserver:
++
++            if ((size_t) n - i >= sizeof("nameserver ") - 1
++                && ngx_memcmp(buf + i, "nameserver ",
++                              sizeof("nameserver ") - 1) == 0)
++            {
++                state = sw_address;
++                address = 0;
++                i += sizeof("nameserver ") - 1;
++
++                continue;
++            }
++
++            break;
++
++        case sw_address:
++
++            if (address == 0) {
++                address = i;
++            }
++
++            if (buf[i] == LF || i == n - 1) {
++                ngx_memzero(&u, sizeof(ngx_url_t));
++
++                u.url.data = buf + address;
++                u.url.len = i - address;
++                u.default_port = 53;
++
++                if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
++                    if (u.err) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "%s in resolver \"%V\"",
++                                           u.err, &u.url);
++                    }
++
++                    return NGX_ERROR;
++                }
++
++                rec = ngx_array_push_n(&r->connections, u.naddrs);
++                if (rec == NULL) {
++                    return NGX_ERROR;
++                }
++
++                ngx_memzero(rec, u.naddrs * sizeof(ngx_resolver_connection_t));
++
++                for (j = 0; j < u.naddrs; j++) {
++                    rec[j].sockaddr = u.addrs[j].sockaddr;
++                    rec[j].socklen = u.addrs[j].socklen;
++                    rec[j].server = u.addrs[j].name;
++                    rec[j].resolver = r;
++                }
++
++                address = 0;
++                state = sw_nameserver;
++            }
++
++            break;
++
++        case sw_skip:
++            if (buf[i] == LF) {
++                state = sw_nameserver;
++            }
++
++            break;
++        }
++
++        i++;
++    }
++
++    return NGX_OK;
++}
++
++
+ ngx_resolver_t *
+ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+ {
+@@ -246,6 +386,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+         }
+ #endif
+ 
++        if (ngx_strncmp(names[i].data, "local=", 6) == 0) {
++
++            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  NGX_RESOLVER_FILE_NAME)
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            } else if (ngx_strcmp(&names[i].data[6], "off") != 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  &names[i].data[6])
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            }
++
++            continue;
++        }
++
+         ngx_memzero(&u, sizeof(ngx_url_t));
+ 
+         u.url = names[i];

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..e61a6d53 100644
+index cd55520c..6a3f98bb 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
 @@ -5,6 +5,7 @@
@@ -10,17 +10,22 @@ index cd55520c..e61a6d53 100644
  #include <ngx_config.h>
  #include <ngx_core.h>
  #include <ngx_event.h>
-@@ -15,6 +16,9 @@
+@@ -15,6 +16,14 @@
  #define NGX_RESOLVER_TCP_RSIZE  (2 + 65535)
  #define NGX_RESOLVER_TCP_WSIZE  8192
  
++/*
++ * note that 2KB should be more than enough for majority of the
++ * resolv.conf files out there. it also acts as a safety guard to prevent
++ * abuse.
++ */
 +#define NGX_RESOLVER_FILE_BUF_SIZE  2048
 +#define NGX_RESOLVER_FILE_NAME      "/etc/resolv.conf"
 +
  
  typedef struct {
      u_char  ident_hi;
-@@ -131,6 +135,144 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+@@ -131,6 +140,138 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
  #endif
  
  
@@ -60,8 +65,6 @@ index cd55520c..e61a6d53 100644
 +    ngx_memzero(&file, sizeof(ngx_file_t));
 +
 +    file.fd = fd;
-+    file.name.data = path;
-+    file.name.len = ngx_strlen(path) - 1;
 +    file.log = cf->log;
 +
 +    state = sw_nameserver;
@@ -81,7 +84,7 @@ index cd55520c..e61a6d53 100644
 +        return NGX_OK;
 +    }
 +
-+    for (i = 0; i < n; total < MAXNS) {
++    for (i = 0; i < n && total < MAXNS; /* void */) {
 +        if (buf[i] == '#' || buf[i] == ';') {
 +            state = sw_skip;
 +        }
@@ -95,8 +98,8 @@ index cd55520c..e61a6d53 100644
 +                              sizeof("nameserver ") - 1) == 0)
 +            {
 +                state = sw_address;
-+                address = 0;
 +                i += sizeof("nameserver ") - 1;
++                address = i;
 +
 +                continue;
 +            }
@@ -104,10 +107,6 @@ index cd55520c..e61a6d53 100644
 +            break;
 +
 +        case sw_address:
-+
-+            if (address == 0) {
-+                address = i;
-+            }
 +
 +            if (buf[i] == CR || buf[i] == LF || i == n - 1) {
 +                ngx_memzero(&u, sizeof(ngx_url_t));
@@ -165,7 +164,7 @@ index cd55520c..e61a6d53 100644
  ngx_resolver_t *
  ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
  {
-@@ -246,6 +388,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+@@ -246,6 +387,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
          }
  #endif
  
@@ -173,7 +172,7 @@ index cd55520c..e61a6d53 100644
 +
 +            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
 +                if (ngx_resolver_read_resolv_conf(cf, r,
-+                                                  NGX_RESOLVER_FILE_NAME)
++                                                  (u_char *) NGX_RESOLVER_FILE_NAME)
 +                    != NGX_OK)
 +                {
 +                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,8 +1,16 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..efa9ef55 100644
+index cd55520c..e61a6d53 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
-@@ -15,6 +15,9 @@
+@@ -5,6 +5,7 @@
+  */
+ 
+ 
++#include <resolv.h>
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_event.h>
+@@ -15,6 +16,9 @@
  #define NGX_RESOLVER_TCP_RSIZE  (2 + 65535)
  #define NGX_RESOLVER_TCP_WSIZE  8192
  
@@ -12,7 +20,7 @@ index cd55520c..efa9ef55 100644
  
  typedef struct {
      u_char  ident_hi;
-@@ -131,6 +134,142 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+@@ -131,6 +135,144 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
  #endif
  
  
@@ -24,7 +32,7 @@ index cd55520c..efa9ef55 100644
 +    ngx_fd_t                         fd;
 +    ngx_file_t                       file;
 +    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
-+    ngx_uint_t                       address, j;
++    ngx_uint_t                       address, j, total = 0;
 +    ssize_t                          n, i;
 +    enum {
 +        sw_nameserver,
@@ -73,7 +81,7 @@ index cd55520c..efa9ef55 100644
 +        return NGX_OK;
 +    }
 +
-+    for (i = 0; i < n; /* void */) {
++    for (i = 0; i < n; total < MAXNS) {
 +        if (buf[i] == '#' || buf[i] == ';') {
 +            state = sw_skip;
 +        }
@@ -132,6 +140,8 @@ index cd55520c..efa9ef55 100644
 +                    rec[j].resolver = r;
 +                }
 +
++                total++;
++
 +                state = sw_nameserver;
 +            }
 +
@@ -155,7 +165,7 @@ index cd55520c..efa9ef55 100644
  ngx_resolver_t *
  ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
  {
-@@ -246,6 +385,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+@@ -246,6 +388,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
          }
  #endif
  

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..d91c406c 100644
+index cd55520c..9156fadd 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
 @@ -5,6 +5,7 @@
@@ -25,7 +25,7 @@ index cd55520c..d91c406c 100644
  
  typedef struct {
      u_char  ident_hi;
-@@ -131,6 +140,180 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+@@ -131,6 +140,182 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
  #endif
  
  
@@ -127,15 +127,17 @@ index cd55520c..d91c406c 100644
 +                ngx_memzero(&u, sizeof(ngx_url_t));
 +
 +                u.url.data = buf + address;
-+                u.url.len = i == n - 1 ? n - address : i - address;
++                u.url.len = (i == n - 1) ? n - address : i - address;
 +                u.default_port = 53;
 +
 +                /* IPv6? */
-+                if (ngx_strlchr(u.url.data, u.url.data + u.url.len, ':') != NULL) {
++                if (ngx_strlchr(u.url.data, u.url.data + u.url.len,
++                                ':') != NULL)
++                {
 +                    if (u.url.len + 2 > sizeof(ipv6_buf)) {
 +                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-+                                           "IPv6 resolver address is too long: \"%V\"",
-+                                           &u.url);
++                                           "IPv6 resolver address is too long:"
++                                           " \"%V\"", &u.url);
 +
 +                        return NGX_ERROR;
 +                    }
@@ -206,7 +208,7 @@ index cd55520c..d91c406c 100644
  ngx_resolver_t *
  ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
  {
-@@ -246,6 +429,35 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+@@ -246,6 +431,37 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
          }
  #endif
  
@@ -214,8 +216,10 @@ index cd55520c..d91c406c 100644
 +
 +            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
 +                if (ngx_resolver_read_resolv_conf(cf, r,
-+                                                  (u_char *) NGX_RESOLVER_FILE_NAME,
-+                                                  sizeof(NGX_RESOLVER_FILE_NAME) - 1)
++                                                  (u_char *)
++                                                  NGX_RESOLVER_FILE_NAME,
++                                                  sizeof(NGX_RESOLVER_FILE_NAME)
++                                                  - 1)
 +                    != NGX_OK)
 +                {
 +                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/patches/nginx-1.13.6-resolver_conf_parsing.patch
+++ b/patches/nginx-1.13.6-resolver_conf_parsing.patch
@@ -1,5 +1,5 @@
 diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
-index cd55520c..06d1c461 100644
+index cd55520c..efa9ef55 100644
 --- a/src/core/ngx_resolver.c
 +++ b/src/core/ngx_resolver.c
 @@ -15,6 +15,9 @@
@@ -12,7 +12,7 @@ index cd55520c..06d1c461 100644
  
  typedef struct {
      u_char  ident_hi;
-@@ -131,6 +134,143 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+@@ -131,6 +134,142 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
  #endif
  
  
@@ -101,7 +101,7 @@ index cd55520c..06d1c461 100644
 +                address = i;
 +            }
 +
-+            if (buf[i] == LF || i == n - 1) {
++            if (buf[i] == CR || buf[i] == LF || i == n - 1) {
 +                ngx_memzero(&u, sizeof(ngx_url_t));
 +
 +                u.url.data = buf + address;
@@ -132,14 +132,13 @@ index cd55520c..06d1c461 100644
 +                    rec[j].resolver = r;
 +                }
 +
-+                address = 0;
 +                state = sw_nameserver;
 +            }
 +
 +            break;
 +
 +        case sw_skip:
-+            if (buf[i] == LF) {
++            if (buf[i] == CR || buf[i] == LF) {
 +                state = sw_nameserver;
 +            }
 +
@@ -156,7 +155,7 @@ index cd55520c..06d1c461 100644
  ngx_resolver_t *
  ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
  {
-@@ -246,6 +386,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+@@ -246,6 +385,33 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
          }
  #endif
  

--- a/t/000-resolver.t
+++ b/t/000-resolver.t
@@ -248,7 +248,7 @@ parsed a resolver: "8.8.4.4"
 
 
 
-=== TEST 8: MAXNS is respected (on standard Glibc it is 3)
+=== TEST 8: MAXNS is respected (in standard Glibc it is 3)
 --- config
     resolver local=../html/resolv.conf ipv6=off;
     resolver_timeout 5s;

--- a/t/000-resolver.t
+++ b/t/000-resolver.t
@@ -1,0 +1,136 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+log_level('warn');
+
+#repeat_each(120);
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 2);
+
+#no_diff();
+#no_long_string();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: use system resolver
+--- config
+    resolver local=on ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- request
+GET /t
+--- response_body
+successfully connected to openresty.org
+--- no_error
+[error]
+[crit]
+
+
+
+=== TEST 2: malformed file
+--- config
+    resolver local=../html/resolv.conf ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- user_files eval
+">>> resolv.conf
+nameser 8.8.8.8"
+--- request
+GET /t
+--- response_body
+failed to connect to nil: no resolver defined to resolve "openresty.org"
+--- no_error
+[error]
+[crit]
+
+
+
+=== TEST 3: disabled
+--- config
+    resolver local=off ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- user_files eval
+">>> resolv.conf
+nameser 8.8.8.8"
+--- request
+GET /t
+--- response_body
+failed to connect to nil: no resolver defined to resolve "openresty.org"
+--- no_error
+[error]
+[crit]
+
+
+
+=== TEST 4: multiple resolvers
+--- config
+    resolver local=../html/resolv.conf ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- user_files eval
+">>> resolv.conf
+domain example.com
+nameserver 8.8.8.8
+nameserver 8.8.4.4"
+--- request
+GET /t
+--- response_body
+successfully connected to openresty.org
+--- no_error
+[error]
+[crit]

--- a/t/000-resolver.t
+++ b/t/000-resolver.t
@@ -134,3 +134,63 @@ successfully connected to openresty.org
 --- no_error
 [error]
 [crit]
+
+
+
+=== TEST 5: CRLF
+--- config
+    resolver local=../html/resolv.conf ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- user_files eval
+">>> resolv.conf
+domain example.com\r\nnameserver 8.8.8.8\r\nnameserver 8.8.4.4"
+--- request
+GET /t
+--- response_body
+successfully connected to openresty.org
+--- no_error
+[error]
+[crit]
+
+
+
+=== TEST 6: CR only, with comments
+--- config
+    resolver local=../html/resolv.conf ipv6=off;
+    resolver_timeout 5s;
+
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("openresty.org", 80)
+            if not ok then
+                ngx.say("failed to connect to ", server, ": ", err)
+                return
+            end
+            ngx.say("successfully connected to openresty.org")
+            sock:close()
+        }
+    }
+--- user_files eval
+">>> resolv.conf
+#domain example.com\rnameserver 8.8.8.8\rnameserver 8.8.4.4"
+--- request
+GET /t
+--- response_body
+successfully connected to openresty.org
+--- no_error
+[error]
+[crit]

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -61,6 +61,10 @@ if [ "$answer" = "Y" ]; then
     echo "$info_txt applying the stream_ssl_preread_no_skip patch for nginx"
     patch -p1 < $root/patches/nginx-$main_ver-stream_ssl_preread_no_skip.patch || exit 1
     echo
+
+    echo "$info_txt applying the resolver_conf_parsing patch for nginx"
+    patch -p1 < $root/patches/nginx-$main_ver-resolver_conf_parsing.patch || exit 1
+    echo
 fi
 
 answer=`$root/util/ver-ge "$main_ver" 1.5.12`

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -1,0 +1,209 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:ngx_init_cycle
+   fun:ngx_master_process_cycle
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:ngx_init_cycle
+   fun:ngx_master_process_cycle
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:ngx_vslprintf
+   fun:ngx_snprintf
+   fun:ngx_sock_ntop
+   fun:ngx_event_accept
+   fun:ngx_epoll_process_events
+   fun:ngx_process_events_and_timers
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr1
+   fun:ngx_vslprintf
+   fun:ngx_snprintf
+   fun:ngx_sock_ntop
+   fun:ngx_event_accept
+}
+{
+   <insert_a_suppression_name_here>
+   exp-sgcheck:SorG
+   fun:ngx_http_lua_ndk_set_var_get
+}
+{
+   <insert_a_suppression_name_here>
+   exp-sgcheck:SorG
+   fun:ngx_http_variables_init_vars
+   fun:ngx_http_block
+}
+{
+   <insert_a_suppression_name_here>
+   exp-sgcheck:SorG
+   fun:ngx_conf_parse
+}
+{
+   <insert_a_suppression_name_here>
+   exp-sgcheck:SorG
+   fun:ngx_vslprintf
+   fun:ngx_log_error_core
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   epoll_ctl(event)
+   fun:epoll_ctl
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:ngx_conf_flush_files
+   fun:ngx_single_process_cycle
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:memcpy
+   fun:ngx_vslprintf
+   fun:ngx_log_error_core
+   fun:ngx_http_charset_header_filter
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   socketcall.setsockopt(optval)
+   fun:setsockopt
+   fun:drizzle_state_connect
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:ngx_conf_flush_files
+   fun:ngx_single_process_cycle
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   fun:malloc
+   fun:ngx_alloc
+   fun:ngx_event_process_init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   sendmsg(mmsg[0].msg_hdr)
+   fun:sendmmsg
+   fun:__libc_res_nsend
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   sendmsg(msg.msg_iov[0])
+   fun:__sendmsg_nocancel
+   fun:ngx_write_channel
+   fun:ngx_pass_open_channel
+   fun:ngx_start_cache_manager_processes
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:ngx_init_cycle
+   fun:ngx_master_process_cycle
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:index
+   fun:expand_dynamic_string_token
+   fun:_dl_map_object
+   fun:map_doit
+   fun:_dl_catch_error
+   fun:do_preload
+   fun:dl_main
+   fun:_dl_sysdep_start
+   fun:_dl_start
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   sendmsg(mmsg[0].msg_hdr)
+   fun:sendmmsg
+   fun:__libc_res_nsend
+   fun:__libc_res_nquery
+   fun:__libc_res_nquerydomain
+   fun:__libc_res_nsearch
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ngx_alloc
+   fun:ngx_set_environment
+   fun:ngx_single_process_cycle
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   obj:*
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ngx_alloc
+   fun:ngx_set_environment
+   fun:ngx_worker_process_init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ngx_alloc
+   fun:ngx_create_pool
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   epoll_pwait(sigmask)
+   fun:epoll_pwait
+   fun:epoll_wait
+   fun:ngx_epoll_process_events
+   fun:ngx_process_events_and_timers
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   epoll_pwait(sigmask)
+   fun:epoll_pwait
+   fun:epoll_wait
+   fun:ngx_epoll_test_rdhup
+   fun:ngx_epoll_init
+   fun:ngx_event_process_init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   epoll_pwait(sigmask)
+   fun:epoll_pwait
+   fun:ngx_epoll_process_events
+   fun:ngx_process_events_and_timers
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   epoll_pwait(sigmask)
+   fun:epoll_pwait
+   fun:ngx_epoll_test_rdhup
+   fun:ngx_epoll_init
+   fun:ngx_event_process_init
+}


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

Usage:
**resolver** address ... [valid=time] [ipv6=on|off] [local=on|off|path];

This can be used inside both `http` and `stream` subsystem.

If `local=on`, then in addition to the resolvers specified, NGINX will parse `/etc/resolv.conf` and use nameservers found inside as resolvers. You can also specify `local=path` to use a different file instead. By default, the path is relative to `nginx_prefix/conf`.

`local=off` will disable the parsing (this is the default).

Note that we only parse the first 2048 bytes of data from the `resolve.conf` file. In practice this should be more than enough as most of the time the size of this file is well under few hundred bytes.