### PR TITLE
configure: put lua-resty libs into a list, and make all operations on lua-resty opts use that list

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -88,6 +88,21 @@ my @modules = (
     [stream_lua => 'ngx_stream_lua'],
 );
 
+my @lua_resty_libs = (
+    'core',
+    'dns',
+    'limit_traffic',
+    'lock',
+    'lrucache',
+    'memcached',
+    'mysql',
+    'redis',
+    'string',
+    'upload',
+    'upstream_healthcheck',
+    'websocket',
+);
+
 my $without_resty_mods_regex;
 {
     my $s = '^--without-('
@@ -116,6 +131,17 @@ my $with_resty_mods_regex;
     #warn "with regex: $s";
 
     $with_resty_mods_regex = qr/$s/;
+}
+
+my $without_lua_resty_libs_regex;
+{
+    my $s = '^--without-lua_resty_('
+        . join('|',
+            @lua_resty_libs
+          )
+        . ')$';
+
+    $without_lua_resty_libs_regex = qr/$s/;
 }
 
 my $prefix = '/usr/local/openresty';
@@ -180,51 +206,6 @@ for my $opt (@ARGV) {
         $resty_opts{no_ndk} = 1;
         push @ngx_opts, $opt;
 
-    } elsif ($opt eq '--without-lua_cjson') {
-        $resty_opts{no_lua_cjson} = 1;
-
-    } elsif ($opt eq '--without-lua_redis_parser') {
-        $resty_opts{no_lua_redis_parser} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_memcached') {
-        $resty_opts{no_lua_resty_memcached} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_redis') {
-        $resty_opts{no_lua_resty_redis} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_dns') {
-        $resty_opts{no_lua_resty_dns} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_mysql') {
-        $resty_opts{no_lua_resty_mysql} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_upload') {
-        $resty_opts{no_lua_resty_upload} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_string') {
-        $resty_opts{no_lua_resty_string} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_limit_traffic') {
-        $resty_opts{no_lua_resty_limit_traffic} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_websocket') {
-        $resty_opts{no_lua_resty_websocket} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_lock') {
-        $resty_opts{no_lua_resty_lock} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_lrucache') {
-        $resty_opts{no_lua_resty_lrucache} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_core') {
-        $resty_opts{no_lua_resty_core} = 1;
-
-    } elsif ($opt eq '--without-lua_resty_upstream_healthcheck') {
-        $resty_opts{no_lua_resty_upstream_healthcheck} = 1;
-
-    } elsif ($opt eq '--without-lua_rds_parser') {
-        $resty_opts{no_lua_rds_parser} = 1;
-
     } elsif ($opt eq '--with-debug') {
         $resty_opts{debug} = 1;
 
@@ -236,16 +217,31 @@ for my $opt (@ARGV) {
 
     } elsif ($opt =~ /^--with-ld-opt=(.*)/) {
         push @ngx_ld_opts, $1;
+        
+    } elsif ($opt eq '--without-ngx_devel_kit_module') {
+        $resty_opts{no_ndk} = 1;
 
     } elsif ($opt =~ $without_resty_mods_regex) {
         #die "no_$1\n";
         $resty_opts{"no_$1"} = 1;
 
-    } elsif ($opt eq '--without-ngx_devel_kit_module') {
-        $resty_opts{no_ndk} = 1;
-
     } elsif ($opt =~ $with_resty_mods_regex) {
         $resty_opts{"$1"} = 1;
+
+    } elsif ($opt =~ $without_lua_resty_libs_regex) {
+        $resty_opts{"no_lua_resty_$1"} = 1;
+    
+    } elsif ($opt =~ /--without-lua_resty_(.*)/) {
+        die "$opt : lib not included";
+    
+    } elsif ($opt eq '--without-lua_cjson') {
+        $resty_opts{no_lua_cjson} = 1;
+
+    } elsif ($opt eq '--without-lua_rds_parser') {
+        $resty_opts{no_lua_rds_parser} = 1;
+
+    } elsif ($opt eq '--without-lua_redis_parser') {
+        $resty_opts{no_lua_redis_parser} = 1;
 
     } elsif ($opt eq '--with-luajit') {
         $resty_opts{luajit} = 1;
@@ -1050,8 +1046,7 @@ _EOC_
                 "\$(MAKE) install$extra_opts";
         }
 
-        for my $key (qw(dns memcached redis mysql string upload websocket
-                        lock lrucache core upstream_healthcheck limit_traffic))
+        for my $key (@lua_resty_libs)
         {
             unless ($opts->{"no_lua_resty_$key"}) {
                 (my $key2 = $key) =~ s/_/-/g;
@@ -1071,7 +1066,8 @@ _EOC_
         }
     }
 
-    # configure opm:
+    # configure opm
+    
     {
         my $opm_dir = auto_complete 'opm';
         my $target_dir;
@@ -1084,7 +1080,7 @@ _EOC_
              . "$root_dir/build/install bin/* $target_dir";
     }
 
-    # configure resty-cli:
+    # configure resty-cli
 
     {
         my $resty_cli_dir = auto_complete 'resty-cli';
@@ -1098,7 +1094,8 @@ _EOC_
              . "$root_dir/build/install bin/* $target_dir";
 
         if ($platform ne 'msys') {
-            # patch the resty script:
+            
+            # patch the resty script
 
             print "patching the resty script with hard-coded nginx binary ",
                   "path...\n";
@@ -1237,19 +1234,26 @@ _EOC_
   --without-lua_cjson                disable the lua-cjson library
   --without-lua_redis_parser         disable the lua-redis-parser library
   --without-lua_rds_parser           disable the lua-rds-parser library
-  --without-lua_resty_dns            disable the lua-resty-dns library
-  --without-lua_resty_memcached      disable the lua-resty-memcached library
-  --without-lua_resty_redis          disable the lua-resty-redis library
-  --without-lua_resty_mysql          disable the lua-resty-mysql library
-  --without-lua_resty_upload         disable the lua-resty-upload library
-  --without-lua_resty_upstream_healthcheck
-                                     disable the lua-resty-upstream-healthcheck library
-  --without-lua_resty_string         disable the lua-resty-string library
-  --without-lua_resty_websocket      disable the lua-resty-websocket library
-  --without-lua_resty_limit_traffic  disable the lua-resty-limit-traffic library
-  --without-lua_resty_lock           disable the lua-resty-lock library
-  --without-lua_resty_lrucache       disable the lua-resty-lrucache library
-  --without-lua_resty_core           disable the lua-resty-core library
+_EOC_
+
+    for my $name (@lua_resty_libs) {
+        
+        my $opt = "  --without-lua_resty_${name}";
+        $msg .= $opt;
+        
+        my $n = $opt_max_len - length $opt;
+
+        if ($n > 0) {
+            $msg .= " " x $n;
+
+        } else {
+            $msg .= "\n" . (" " x $opt_max_len);
+        }
+
+        $msg .= "disable the lua-resty-${name} library\n";
+    }
+
+    $msg .= <<'_EOC_';
 
   --with-luajit                      enable and build the bundled LuaJIT 2.1 (the default)
   --with-luajit=DIR                  use the external LuaJIT 2.1 installation specified by DIR


### PR DESCRIPTION
Reason for patch
=============
The configure file now has quite a large number of included lua-resty-[name] libs, with all references to them statically included in the following places:

1) Configure option parsing (each --without-lua_resty_xxx option)
2) Including the make files (a static list)
3) Configure usage message

This is both more prone to errors, and is inefficient when adding new libs in the future.

What this patch does
================
1) Puts all the lua-resty-[name] libs into a list (underneath the list of modules)
2) Uses the list to generate a regex to test for --without-lua_resty_[name] configure options
3) Uses the list to add the lua-resty-[name] libs to the whole $make process
4) Uses the list to generate the relevant parts of the ./configure --help message
5) A few very minor edits that improve clarity / formatting consistency (that make no changes to the actions)

This makes the whole configure script a bit easier to read, makes it quicker to add new lua-resty-[name] libs to OpenResty, and reduces the possibility for bugs in future edits.

What else you might want to change
============================
I've ordered the lua-resty-[name] modules alphabetically, because I think they're easier to read that way.  Given that the modules are not listed alphabetically in the ./configure --help, you might want to : 

- Re-order the list of lua-resty-[name] libs
- Modify the ./configure script to display the help with the --with-[name]_module and --without-[name]_module so they display alphabetically

I didn't want to presume your choice about this, but if you'd like me to do a quick patch to change that as well, I'm happy to do so.