### PR TITLE
configure: support @rpath placeholder in OS X.

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -341,7 +341,14 @@ if ($platform ne 'msys') {
 my $resty_opts = build_resty_opts(\%resty_opts);
 
 if (@ngx_rpaths) {
-    unshift @ngx_ld_opts, "-Wl,-rpath," . join(":", @ngx_rpaths);
+    if ($platform eq 'macosx') {
+        for (@ngx_rpaths) {
+            unshift @ngx_ld_opts, "-Wl,-rpath," . $_;
+        }
+
+    } else {
+        unshift @ngx_ld_opts, "-Wl,-rpath," . join(":", @ngx_rpaths);
+    }
 }
 
 my $ld_opts = '';


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

Since OS X Leopard, the recommended way of specifying dynamic loading path in OS X is to use the `@rpath` placeholder which will be attempted on each `rpath` specified to the linker. However, according to my test the OS X linker does not correctly interpret multiple paths separated with `:` like the GNU linker does and this will cause libraries searched with the `@rpath` placeholder to not work. Instead we specify a separate `rpath` option for each path under OS X to get around this problem.

See https://wincent.com/wiki/@executable_path,_@load_path_and_@rpath for more info about this.