### PR TITLE
bugfix: nginx did not destroy the cycle memory pool before the nginx test configuration process exits.

### DIFF
--- a/patches/nginx-1.13.6-test_config_destroy_pool.patch
+++ b/patches/nginx-1.13.6-test_config_destroy_pool.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/nginx.c b/src/core/nginx.c
+index abaa50d6..6369264e 100644
+--- a/src/core/nginx.c
++++ b/src/core/nginx.c
+@@ -314,6 +314,8 @@ main(int argc, char *const *argv)
+             }
+         }
+ 
++        /* just to make it ASAN or Valgrind clean */
++        ngx_destroy_pool(cycle->pool);
+         return 0;
+     }
+ 

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -400,6 +400,12 @@ if [ "$main_ver" = "1.13.6" ]; then
     echo
 fi
 
+if [ "$main_ver" = "1.13.6" ]; then
+    echo "$info_txt applying the test_config_destroy_pool patch for nginx"
+    patch -p1 < $root/patches/nginx-$main_ver-test_config_destroy_pool.patch || exit 1
+    echo
+fi
+
 rm -f *.patch || exit 1
 
 echo "$info_txt applying the always_enable_cc_feature_tests patch to nginx"


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.