### PR TITLE
test: fixed test failure due to NGINX core change introduced in 1.15.1

### DIFF
--- a/t/001-resolver.t
+++ b/t/001-resolver.t
@@ -68,12 +68,14 @@ parsed a resolver: "
 nameser 8.8.8.8"
 --- request
 GET /t
---- response_body
-failed to connect to openresty.org: no resolver defined to resolve "openresty.org"
+--- must_die
+--- error_log
+no name servers defined
 --- no_error_log
 [error]
 [crit]
 parsed a resolver: "
+--- skip_nginx: 5: < 1.15.1
 
 
 
@@ -99,12 +101,14 @@ parsed a resolver: "
 nameser 8.8.8.8"
 --- request
 GET /t
---- response_body
-failed to connect to openresty.org: no resolver defined to resolve "openresty.org"
+--- must_die
+--- error_log
+no name servers defined
 --- no_error_log
 [error]
 [crit]
 parsed a resolver: "
+--- skip_nginx: 5: < 1.15.1
 
 
 


### PR DESCRIPTION
by https://github.com/nginx/nginx/commit/63e8a1d926251469b708c6248c3b1849bd018b40.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
