### PR TITLE
Backport the nginx Patch for Building on Fedora 28+

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -58,6 +58,10 @@ fi
 
 answer=`$root/util/ver-ge "$main_ver" 1.13.6`
 if [ "$answer" = "Y" ]; then
+    echo "$info_txt applying the remove_glibc_crypt_workaround patch for nginx"
+    patch -p1 < $root/patches/nginx-$main_ver-remove_glibc_crypt_workaround.patch || exit 1
+    echo
+
     echo "$info_txt applying the stream_ssl_preread_no_skip patch for nginx"
     patch -p1 < $root/patches/nginx-$main_ver-stream_ssl_preread_no_skip.patch || exit 1
     echo

--- a/util/ver
+++ b/util/ver
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 main_ver=1.13.6
-minor_ver=2
+minor_ver=3
 version=$main_ver.$minor_ver
 echo $version
-


### PR DESCRIPTION
Nginx removed this particular workaround in version 14.2 - we want to
be able to build 13.6 as well.

Signed-off-by: Christoph Höger <christoph.hoeger@celeraone.com>

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
