### PR TITLE
bugfix: we don't download tar.bz2 archive anymore.

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -884,7 +884,6 @@ cd ..
 #################################
 
 rm *.tar.gz
-rm *.tar.bz2
 
 cd ..
 cp $root/util/configure ./ || exit 1


### PR DESCRIPTION
Therefore, there is no need to run the 'rm' command.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
