### PR TITLE
bugfix: patches for NGINX core CVE-2018-16843, CVE-2018-16844, CVE-2019-9511, CVE-2019-9513, and CVE-2019-9516.

### DIFF
--- a/patches/patch.2018.h2.txt
+++ b/patches/patch.2018.h2.txt
@@ -1,0 +1,81 @@
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -662,6 +662,7 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
+ 
+     h2c->pool = NULL;
+     h2c->free_frames = NULL;
++    h2c->frames = 0;
+     h2c->free_fake_connections = NULL;
+ 
+ #if (NGX_HTTP_SSL)
+@@ -2895,7 +2896,7 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+ 
+         frame->blocked = 0;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         pool = h2c->pool ? h2c->pool : h2c->connection->pool;
+ 
+         frame = ngx_pcalloc(pool, sizeof(ngx_http_v2_out_frame_t));
+@@ -2919,6 +2920,15 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+         frame->last = frame->first;
+ 
+         frame->handler = ngx_http_v2_frame_handler;
++
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+ #if (NGX_DEBUG)
+--- src/http/v2/ngx_http_v2.h
++++ src/http/v2/ngx_http_v2.h
+@@ -120,6 +120,7 @@ struct ngx_http_v2_connection_s {
+     ngx_http_connection_t           *http_connection;
+ 
+     ngx_uint_t                       processing;
++    ngx_uint_t                       frames;
+ 
+     ngx_uint_t                       pushing;
+     ngx_uint_t                       concurrent_pushes;
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -4511,12 +4511,19 @@ ngx_http_v2_idle_handler(ngx_event_t *rev)
+ 
+ #endif
+ 
+-    c->destroyed = 0;
+-    ngx_reusable_connection(c, 0);
+-
+     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                          ngx_http_v2_module);
+ 
++    if (h2c->idle++ > 10 * h2scf->max_requests) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++        ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_NO_ERROR);
++        return;
++    }
++
++    c->destroyed = 0;
++    ngx_reusable_connection(c, 0);
++
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+         ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+--- src/http/v2/ngx_http_v2.h
++++ src/http/v2/ngx_http_v2.h
+@@ -121,6 +121,7 @@ struct ngx_http_v2_connection_s {
+ 
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
++    ngx_uint_t                       idle;
+ 
+     ngx_uint_t                       pushing;
+     ngx_uint_t                       concurrent_pushes;
+

--- a/patches/patch.2019.h2.txt
+++ b/patches/patch.2019.h2.txt
@@ -1,0 +1,136 @@
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -1546,6 +1546,14 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+         header->name.len = h2c->state.field_end - h2c->state.field_start;
+         header->name.data = h2c->state.field_start;
+ 
++        if (header->name.len == 0) {
++            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                          "client sent zero header name length");
++
++            return ngx_http_v2_connection_error(h2c,
++                                                NGX_HTTP_V2_PROTOCOL_ERROR);
++        }
++
+         return ngx_http_v2_state_field_len(h2c, pos, end);
+     }
+ 
+@@ -3249,10 +3257,6 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
+     ngx_uint_t                 i;
+     ngx_http_core_srv_conf_t  *cscf;
+ 
+-    if (header->name.len == 0) {
+-        return NGX_ERROR;
+-    }
+-
+     r->invalid_header = 0;
+ 
+     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -4369,6 +4369,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
+      */
+     pool = stream->pool;
+ 
++    h2c->frames -= stream->frames;
++
+     ngx_http_free_request(stream->request, rc);
+ 
+     if (pool != h2c->state.pool) {
+--- src/http/v2/ngx_http_v2.h
++++ src/http/v2/ngx_http_v2.h
+@@ -192,6 +192,8 @@ struct ngx_http_v2_stream_s {
+ 
+     ngx_buf_t                       *preread;
+ 
++    ngx_uint_t                       frames;
++
+     ngx_http_v2_out_frame_t         *free_frames;
+     ngx_chain_t                     *free_frame_headers;
+     ngx_chain_t                     *free_bufs;
+--- src/http/v2/ngx_http_v2_filter_module.c
++++ src/http/v2/ngx_http_v2_filter_module.c
+@@ -1669,22 +1669,34 @@ static ngx_http_v2_out_frame_t *
+ ngx_http_v2_filter_get_data_frame(ngx_http_v2_stream_t *stream,
+     size_t len, ngx_chain_t *first, ngx_chain_t *last)
+ {
+-    u_char                    flags;
+-    ngx_buf_t                *buf;
+-    ngx_chain_t              *cl;
+-    ngx_http_v2_out_frame_t  *frame;
++    u_char                     flags;
++    ngx_buf_t                 *buf;
++    ngx_chain_t               *cl;
++    ngx_http_v2_out_frame_t   *frame;
++    ngx_http_v2_connection_t  *h2c;
+ 
+     frame = stream->free_frames;
++    h2c = stream->connection;
+ 
+     if (frame) {
+         stream->free_frames = frame->next;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         frame = ngx_palloc(stream->request->pool,
+                            sizeof(ngx_http_v2_out_frame_t));
+         if (frame == NULL) {
+             return NULL;
+         }
++
++        stream->frames++;
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+     flags = last->buf->last_buf ? NGX_HTTP_V2_END_STREAM_FLAG : 0;
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -273,6 +273,7 @@ ngx_http_v2_init(ngx_event_t *rev)
+     h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+ 
+     h2c->concurrent_pushes = h2scf->concurrent_pushes;
++    h2c->priority_limit = h2scf->concurrent_streams;
+ 
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+@@ -1804,6 +1805,13 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
+         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+     }
+ 
++    if (--h2c->priority_limit == 0) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many PRIORITY frames");
++
++        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
++    }
++
+     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
+         return ngx_http_v2_state_save(h2c, pos, end,
+                                       ngx_http_v2_state_priority);
+@@ -3120,6 +3128,8 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c, ngx_uint_t push)
+         h2c->processing++;
+     }
+ 
++    h2c->priority_limit += h2scf->concurrent_streams;
++
+     return stream;
+ }
+ 
+--- src/http/v2/ngx_http_v2.h
++++ src/http/v2/ngx_http_v2.h
+@@ -122,6 +122,7 @@ struct ngx_http_v2_connection_s {
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
+     ngx_uint_t                       idle;
++    ngx_uint_t                       priority_limit;
+ 
+     ngx_uint_t                       pushing;
+     ngx_uint_t                       concurrent_pushes;
+

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -411,7 +411,7 @@ if [ "$answer" = "Y" ]; then
         echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16843 CVE-2018-16844)"
         patch -p0 < $root/patches/patch.2018.h2.txt || exit 1
         echo
-    else
+    elif [ `$root/util/ver-ge "$main_ver" 1.15.0` = "Y" ]; then
         answer=`$root/util/ver-ge "$main_ver" 1.15.6`
         if [ "$answer" = "N" ]; then
             echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16843 CVE-2018-16844)"
@@ -432,6 +432,23 @@ else
         echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16845)"
         patch -p0 < $root/patches/patch.2018.mp4.txt || exit 1
         echo
+    fi
+fi
+
+answer=`$root/util/ver-ge "$main_ver" 1.9.5`
+if [ "$answer" = "Y" ]; then
+    answer=`$root/util/ver-ge "$main_ver" 1.16.1`
+    if [ "$answer" = "N" ]; then
+        echo "$info_txt applying the patch for nginx security advisory (CVE-2019-9511 CVE-2019-9513 CVE-2019-9516)"
+        patch -p0 < $root/patches/patch.2019.h2.txt || exit 1
+        echo
+    elif [ `$root/util/ver-ge "$main_ver" 1.17.0` = "Y" ]; then
+        answer=`$root/util/ver-ge "$main_ver" 1.17.3`
+        if [ "$answer" = "N" ]; then
+            echo "$info_txt applying the patch for nginx security advisory (CVE-2019-9511 CVE-2019-9513 CVE-2019-9516)"
+            patch -p0 < $root/patches/patch.2019.h2.txt || exit 1
+            echo
+        fi
     fi
 fi
 

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -404,6 +404,23 @@ if [ "$main_ver" = "1.13.6" ]; then
     echo
 fi
 
+answer=`$root/util/ver-ge "$main_ver" 1.9.5`
+if [ "$answer" = "Y" ]; then
+    answer=`$root/util/ver-ge "$main_ver" 1.14.1`
+    if [ "$answer" = "N" ]; then
+        echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16843 CVE-2018-16844)"
+        patch -p0 < $root/patches/patch.2018.h2.txt || exit 1
+        echo
+    else
+        answer=`$root/util/ver-ge "$main_ver" 1.15.6`
+        if [ "$answer" = "N" ]; then
+            echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16843 CVE-2018-16844)"
+            patch -p0 < $root/patches/patch.2018.h2.txt || exit 1
+            echo
+        fi
+    fi
+fi
+
 answer=`$root/util/ver-ge "$main_ver" 1.14.1`
 if [ "$answer" = "N" ]; then
     echo "$info_txt applying the patch for nginx security advisory (CVE-2018-16845)"


### PR DESCRIPTION
The patches apply cleanly to NGINX cores **1.15.8** and **1.17.2**.

I have also ported those patches to NGINX cores [1.11.2 and 1.13.6](https://gist.github.com/thibaultcha/fabe7857df349ce28ba388474f323429) if desired, but this is not part of this PR. They also apply cleanly (see below), but are **not tested**.

### Note to affected users

Apply the patches to OpenResty 1.15.8.1 today with:

```
$ ls
openresty-1.15.8.1  openresty-1.15.8.1.tar.gz
$ cd openresty-1.15.8.1 
$ wget -q -O - https://raw.githubusercontent.com/openresty/openresty/0a9bbae6e7927f7aad103a32badd8d81ef189a6e/patches/patch.2019.h2.txt | patch -d bundle/nginx-1.15.8/ -p0
patching file src/http/v2/ngx_http_v2.c
patching file src/http/v2/ngx_http_v2.c
patching file src/http/v2/ngx_http_v2.h
patching file src/http/v2/ngx_http_v2_filter_module.c
Hunk #1 succeeded at 1663 (offset -6 lines).
patching file src/http/v2/ngx_http_v2.c
patching file src/http/v2/ngx_http_v2.h
$ ./configure ...
```

OpenResty 1.13.6.2 (not tested):

```
$ ls
openresty-1.13.6.2  openresty-1.13.6.2.tar.gz
$ cd openresty-1.13.6.2
$ wget -q -O - https://gist.github.com/thibaultcha/fabe7857df349ce28ba388474f323429/raw/278934ad3bd6a268563cb36e4e1ec3dbe7a81efb/nginx-1.13.6-cve_2018_16843_cve_2018_16844.patch | patch -d bundle/nginx-1.13.6/ -p1
...
$ wget -q -O - https://gist.github.com/thibaultcha/fabe7857df349ce28ba388474f323429/raw/278934ad3bd6a268563cb36e4e1ec3dbe7a81efb/nginx-1.13.6-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch | patch -d bundle/nginx-1.13.6/ -p1
...
$ ./configure ...
```

OpenResty 1.11.2.5 (not tested):

```
$ ls
openresty-1.11.2.5  openresty-1.11.2.5.tar.gz
$ cd openresty-1.11.2.5
$ wget -q -O - https://gist.github.com/thibaultcha/fabe7857df349ce28ba388474f323429/raw/278934ad3bd6a268563cb36e4e1ec3dbe7a81efb/nginx-1.11.2-cve_2018_16843_cve_2018_16844.patch | patch -d bundle/nginx-1.11.2/ -p1
...
$ wget -q -O - https://gist.github.com/thibaultcha/fabe7857df349ce28ba388474f323429/raw/278934ad3bd6a268563cb36e4e1ec3dbe7a81efb/nginx-1.11.2-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch | patch -d bundle/nginx-1.11.2/ -p1
...
$ ./configure ...
```

> I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.