### PR TITLE
optimize: configure generate more elegant lib info

### DIFF
--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1413,8 +1413,8 @@ install: all
 clean:
 	rm -rf build
 --- err
-Can't exec "gcc-4.2": No such file or directory at ./configure line 710.
-Can't exec "gcc-4.2": No such file or directory at ./configure line 756.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 715.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 761.
 
 
 
@@ -1594,8 +1594,8 @@ install: all
 clean:
 	rm -rf build
 --- err
-Can't exec "cl": No such file or directory at ./configure line 710.
-Can't exec "cl": No such file or directory at ./configure line 756.
+Can't exec "cl": No such file or directory at ./configure line 715.
+Can't exec "cl": No such file or directory at ./configure line 761.
 
 
 
@@ -2438,7 +2438,7 @@ install: all
 clean:
 	rm -rf build
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 824.
+Can't exec "sw_vers": No such file or directory at ./configure line 829.
 
 
 
@@ -2528,7 +2528,7 @@ install: all
 clean:
 	rm -rf build
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 824.
+Can't exec "sw_vers": No such file or directory at ./configure line 829.
 
 
 

--- a/util/configure
+++ b/util/configure
@@ -337,14 +337,19 @@ for my $opt (@ARGV) {
 
     } elsif ($opt =~ /^--with-(openssl|pcre|zlib|libatomic|md5|sha1)=(.*)/) {
 
-        my ($lib, $path) = ($1, $2);
+        my ($lib, $path, $bundle) = ($1, $2, File::Spec->rel2abs('bundle'));
         if ($lib eq 'openssl' && $OS eq 'darwin') {
             if (`uname -a` =~ /\bx86_64\b/) {
                 $ENV{KERNEL_BITS} = 64;
                 push @extra_make_env, 'KERNEL_BITS=64';
             }
         }
+        
         $path = File::Spec->rel2abs($path);
+        if ($path =~ /^$bundle(.*)/) {
+            $path = '..'.$1;
+        }
+        
         push @ngx_opts, "--with-$lib=$path";
 
     } elsif ($opt =~ /^--sbin-path=(.*)/) {


### PR DESCRIPTION
Before
```bash
nginx version: openresty/1.15.8.1
built by gcc 4.8.5 20150623 (Red Hat 4.8.5-36) (GCC) 
built with OpenSSL 1.1.0j  20 Nov 2018
TLS SNI support enabled
configure arguments: --prefix=/usr/local/openresty/nginx --with-cc-opt=-O2 --add-module=../ngx_devel_kit-0.3.1rc1 --add-module=../echo-nginx-module-0.61 --add-module=../xss-nginx-module-0.06 --add-module=../ngx_coolkit-0.2 --add-module=../set-misc-nginx-module-0.32 --add-module=../form-input-nginx-module-0.12 --add-module=../encrypted-session-nginx-module-0.08 --add-module=../srcache-nginx-module-0.31 --add-module=../ngx_lua-0.10.15 --add-module=../ngx_lua_upstream-0.07 --add-module=../headers-more-nginx-module-0.33 --add-module=../array-var-nginx-module-0.05 --add-module=../memc-nginx-module-0.19 --add-module=../redis2-nginx-module-0.15 --add-module=../redis-nginx-module-0.3.7 --add-module=../rds-json-nginx-module-0.15 --add-module=../rds-csv-nginx-module-0.09 --add-module=../ngx_stream_lua-0.0.7 --with-ld-opt=-Wl,-rpath,/usr/local/openresty/luajit/lib --with-threads --with-pcre-jit --with-http_v2_module --with-http_addition_module --with-http_auth_request_module 
--with-openssl=/root/OpenResty/openresty-1.15.8.1/openssl-1.1.0j --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-http_ssl_module
```
After:
```bash
nginx version: openresty/1.15.8.1
built by gcc 4.8.5 20150623 (Red Hat 4.8.5-36) (GCC) 
built with OpenSSL 1.1.0k  28 May 2019
TLS SNI support enabled
configure arguments: --prefix=/usr/local/openresty/nginx --with-cc-opt=-O2 --add-module=../ngx_devel_kit-0.3.1rc1 --add-module=../echo-nginx-module-0.61 --add-module=../xss-nginx-module-0.06 --add-module=../ngx_coolkit-0.2 --add-module=../set-misc-nginx-module-0.32 --add-module=../form-input-nginx-module-0.12 --add-module=../encrypted-session-nginx-module-0.08 --add-module=../srcache-nginx-module-0.31 --add-module=../ngx_lua-0.10.15 --add-module=../ngx_lua_upstream-0.07 --add-module=../headers-more-nginx-module-0.33 --add-module=../array-var-nginx-module-0.05 --add-module=../memc-nginx-module-0.19 --add-module=../redis2-nginx-module-0.15 --add-module=../redis-nginx-module-0.3.7 --add-module=../rds-json-nginx-module-0.15 --add-module=../rds-csv-nginx-module-0.09 --add-module=../ngx_stream_lua-0.0.7 --with-ld-opt=-Wl,-rpath,/usr/local/openresty/luajit/lib --with-threads --with-pcre-jit --with-http_v2_module --with-http_addition_module --with-http_auth_request_module --with-pcre=../pcre-8.43 
--with-openssl=../openssl-1.1.0k --with-stream --with-stream_ssl_module --with-stream_ssl_preread_module --with-http_ssl_module
```

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
