### PR TITLE
Move sources targets url to Github releases files.

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -631,8 +631,8 @@ mv openresty-encrypted-session-nginx-module-* encrypted-session-nginx-module-$ve
 #################################
 
 ver=0.3.7
-$root/util/get-tarball "https://people.freebsd.org/~osa/ngx_http_redis-$ver.tar.gz" -O redis-nginx-module-$ver.tar.gz || exit 1
-tar -xzf redis-nginx-module-$ver.tar.gz || exit 1
+$root/util/get-tarball "https://github.com/osokin/ngx_http_redis/archive/$ver.tar.gz" -O redis-nginx-module-$ver.tar.gz || exit 1
+tar -xzf redis-nginx-module-$ver.tar.gz || exit 1j
 mv ngx_http_redis-* redis-nginx-module-$ver || exit 1
 
 cd redis-nginx-module-$ver


### PR DESCRIPTION
To avoid donwload from different places always use the GitHub target
url.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
