### PR TITLE
Adding support for s390x builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,46 @@ addons:
     - dos2unix
     - cpanminus
     - libgd-dev
-
+    
+linux-s390x: &linux-s390x
+  os: linux
+  arch: s390x
+  dist: xenial
+  compiler: gcc
+  addons:
+      apt:
+          update: true
+          packages:
+            - axel
+            - dos2unix
+            - cpanminus
+            - libgd-dev
+            - libpcre3 
+            - libpcre3-dev 
+            - mercurial 
+            - libpq-dev
+  install:
+    - sudo cpanm --notest Test::Nginx IPC::Run3 > build.log 2>&1 || (cat build.log && exit 1)
+    - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
+    - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
+    - cd openssl-$OPENSSL_VER/
+    - patch -p1 < ../patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch
+    - ./config no-threads shared enable-ssl3 enable-ssl3-method -g --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+    - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+    - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
+    - cd ..
+    - sudo ln -s /usr/bin/make /usr/bin/gmake
+  script:
+    - util/mirror-tarballs > build.log 2>&1 || (cat build.log && exit 1)
+    - cd openresty-*
+    - ./configure --prefix=$OPENRESTY_PREFIX --with-cc-opt="-I$PCRE_INC -I$OPENSSL_INC" --with-ld-opt="-L$PCRE_LIB -L$OPENSSL_LIB -Wl,-rpath,$PCRE_LIB:$OPENSSL_LIB" --with-pcre-jit --with-http_ssl_module --with-debug -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+    - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+    - sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+    - cd ..
+    - export PATH=$OPENRESTY_PREFIX/bin:$OPENRESTY_PREFIX/nginx/sbin:$PATH
+    - nginx -V
+    - ldd `which nginx`|grep -E 'luajit|ssl|pcre'
+           
 cache:
   directories:
   - download-cache
@@ -37,6 +76,15 @@ env:
     - OPENSSL_VER=1.1.0j OPENSSL_PATCH_VER=1.1.0d
     - OPENSSL_VER=1.1.1c OPENSSL_PATCH_VER=1.1.1c
 
+jobs:
+    include:
+        - <<: *linux-s390x
+          env: OPENSSL_VER=1.0.2q OPENSSL_PATCH_VER=1.0.2h
+        - <<: *linux-s390x
+          env: OPENSSL_VER=1.1.0j OPENSSL_PATCH_VER=1.1.0d
+        - <<: *linux-s390x
+          env: OPENSSL_VER=1.1.1c OPENSSL_PATCH_VER=1.1.1c       
+          
 install:
   - sudo cpanm --notest Test::Nginx IPC::Run3 > build.log 2>&1 || (cat build.log && exit 1)
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.