### PR TITLE
bugfix: use to LUA_ORIGIN_DEFAULT_CPATH instead of LUA_DEFAULT_PATH avoid dquote in CFLAGS

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -962,9 +962,8 @@ int main(void) {
         {
             print $in <<"_EOC_";
 
-ngx_lua_dquote='"'
-CFLAGS="\$CFLAGS -DLUA_DEFAULT_PATH='\${ngx_lua_dquote}$site_lualib_prefix/?.ljbc;$site_lualib_prefix/?/init.ljbc;$lualib_prefix/?.ljbc;$lualib_prefix/?/init.ljbc;$site_lualib_prefix/?.lua;$site_lualib_prefix/?/init.lua;$lualib_prefix/?.lua;$lualib_prefix/?/init.lua\$ngx_lua_dquote'"
-CFLAGS="\$CFLAGS -DLUA_DEFAULT_CPATH='\${ngx_lua_dquote}$site_lualib_prefix/?.so;$lualib_prefix/?.so\$ngx_lua_dquote'"
+CFLAGS="\$CFLAGS -DLUA_ORIGIN_DEFAULT_PATH='$site_lualib_prefix/?.ljbc;$site_lualib_prefix/?/init.ljbc;$lualib_prefix/?.ljbc;$lualib_prefix/?/init.ljbc;$site_lualib_prefix/?.lua;$site_lualib_prefix/?/init.lua;$lualib_prefix/?.lua;$lualib_prefix/?/init.lua'"
+CFLAGS="\$CFLAGS -DLUA_ORIGIN_DEFAULT_CPATH='$site_lualib_prefix/?.so;$lualib_prefix/?.so'"
 _EOC_
         }
 

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -548,10 +548,10 @@ mv openresty-drizzle-nginx-module-* drizzle-nginx-module-$ver || exit 1
 
 #################################
 
-ver=0.10.16rc4
-$root/util/get-tarball "https://github.com/openresty/lua-nginx-module/archive/v$ver.tar.gz" -O lua-nginx-module-$ver.tar.gz || exit 1
+ver=origin_default_path
+$root/util/get-tarball "https://github.com/rainingmaster/lua-nginx-module/archive/$ver.tar.gz" -O lua-nginx-module-$ver.tar.gz || exit 1
 tar -xzf lua-nginx-module-$ver.tar.gz || exit 1
-mv lua-nginx-module-$ver ngx_lua-$ver || exit 1
+mv lua-nginx-module-$ver ngx_lua-0.10.16rc4 || exit 1
 
 #################################
 
@@ -562,10 +562,10 @@ mv openresty-lua-upstream-nginx-module-* ngx_lua_upstream-$ver || exit 1
 
 #################################
 
-ver=0.0.8rc2
-$root/util/get-tarball "https://github.com/openresty/stream-lua-nginx-module/tarball/v$ver" -O stream-lua-nginx-module-$ver.tar.gz || exit 1
+ver=origin_default_path
+$root/util/get-tarball "https://github.com/rainingmaster/stream-lua-nginx-module/tarball/$ver" -O stream-lua-nginx-module-$ver.tar.gz || exit 1
 tar -xzf stream-lua-nginx-module-$ver.tar.gz || exit 1
-mv openresty-stream-lua-nginx-module-* ngx_stream_lua-$ver || exit 1
+mv rainingmaster-stream-lua-nginx-module-* ngx_stream_lua-0.0.8rc2 || exit 1
 
 #################################
 


### PR DESCRIPTION
Fix this issue: https://github.com/openresty/openresty/issues/587.

The reason for this problem is that escape will work in shell, but not work in the Makefile, such as [this example](https://gist.github.com/doujiang24/fe0c541a585a300fcc3265a4dede0837). When Nginx's makefile is generated, the config.make file of the third-party module is called [here](https://github.com/nginx/nginx/blob/master/auto/make#L445), and the third-party module may use CFLAGS in [config.make](https://github.com/nginx/njs/blob/master/nginx/config.make#L6). When dquote exists in CFLAGS, it will cause an error when executing make, such as this [Makefile](https://gist.github.com/rainingmaster/f5421344a65de13a380d229c261cd537#file-makefile-L3), the CFLAGS is `... -DLUA_DEFAULT_PATH='"/usr/local/openresty/site/lualib/?.ljbc;...`, so build will be broken because CFLAGS will be split to some string in [build/Makefile](https://gist.github.com/rainingmaster/f5421344a65de13a380d229c261cd537#file-makefile-L3007)

Thanks for @doujiang24 's help, we found some way to fix this problem:
1. [By this way](https://github.com/openresty/openresty/issues/587#issuecomment-589814604), we try to add some patch to original NGINX, but found the wrong make file is generate from third part module, such as njs, it is not easy to patch.Another weird way is add some code to escape the CFLAGS when using  build/Makefile in the nginx/objs/Makefile at [nginx's configure](https://github.com/nginx/nginx/blob/master/auto/configure#L105). This solution has not been implemented for the time being.
1. Change the way of define `LUA_DEFAULT_PATH`, such as [this way](https://github.com/rainingmaster/openresty/commit/844b60fd0c0872908cb579f066bf87aee0b3a4ed#diff-7b0d055ed948accb24a95b6de87685b5R965). However, `#` is also need to escape, so when from Makefile(nginx) -> config.make(njs) -> Makefile(njs), it will not work again.
1. It is this PR, we change the way to define the `LUA_DEFAULT_PATH`, such as [this](https://github.com/rainingmaster/lua-nginx-module/commit/9825d0bfa625048f9cff5b062b304074e5af475f#diff-4c237c57e5462e077417a5177672ce82R157), but it will be very complicated because `lua-nginx-module` and `stream-lua-nginx-module` also need to be changed.

@agentzh Do you have any other idea to solve this? Thanks if you can share.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
