### PR TITLE
Update configure

### DIFF
--- a/t/000-sanity.t
+++ b/t/000-sanity.t
@@ -2,7 +2,7 @@
 use lib '.';
 use t::Config;
 
-plan tests => 273;
+plan tests => 270;
 
 #no_diff();
 
@@ -21,8 +21,7 @@ __DATA__
 
   --with-no-pool-patch               enable the no-pool patch for debugging memory issues
 
-  -jN                                pass -jN option to make while building the bundled
-                                     Lua 5.1 interpreter or LuaJIT 2.1
+  -jN                                pass -jN option to make while building LuaJIT 2.1
 
   --without-http_echo_module         disable ngx_http_echo_module
   --without-http_xss_module          disable ngx_http_xss_module
@@ -73,12 +72,11 @@ __DATA__
   --without-lua_resty_shell          disable the lua-resty-shell library
   --without-lua_resty_core           disable the lua-resty-core library
 
-  --with-luajit                      enable and build the bundled LuaJIT 2.1 (the default)
   --with-luajit=DIR                  use the external LuaJIT 2.1 installation specified by DIR
   --with-luajit-xcflags=FLAGS        Specify extra C compiler flags for LuaJIT 2.1
   --with-luajit-ldflags=FLAGS        Specify extra C linker flags for LuaJIT 2.1
   --without-luajit-lua52             Turns off the LuaJIT extensions from Lua 5.2 that may break
-                                     backward compatibility.
+                                     backward compatibility
   --without-luajit-gc64              Turns off the LuaJIT GC64 mode (which is enabled by default
                                      on x86_64)
 
@@ -809,8 +807,7 @@ clean:
 
   --with-no-pool-patch               enable the no-pool patch for debugging memory issues
 
-  -jN                                pass -jN option to make while building the bundled
-                                     Lua 5.1 interpreter or LuaJIT 2.1
+  -jN                                pass -jN option to make while building LuaJIT 2.1
 
   --without-http_echo_module         disable ngx_http_echo_module
   --without-http_xss_module          disable ngx_http_xss_module
@@ -861,12 +858,11 @@ clean:
   --without-lua_resty_shell          disable the lua-resty-shell library
   --without-lua_resty_core           disable the lua-resty-core library
 
-  --with-luajit                      enable and build the bundled LuaJIT 2.1 (the default)
   --with-luajit=DIR                  use the external LuaJIT 2.1 installation specified by DIR
   --with-luajit-xcflags=FLAGS        Specify extra C compiler flags for LuaJIT 2.1
   --with-luajit-ldflags=FLAGS        Specify extra C linker flags for LuaJIT 2.1
   --without-luajit-lua52             Turns off the LuaJIT extensions from Lua 5.2 that may break
-                                     backward compatibility.
+                                     backward compatibility
   --without-luajit-gc64              Turns off the LuaJIT GC64 mode (which is enabled by default
                                      on x86_64)
 
@@ -1046,7 +1042,6 @@ Options directly inherited from nginx
 
   --dry-run                          dry running the configure, for testing only
   --platform=PLATFORM                forcibly specify a platform name, for testing only
-
 
 
 
@@ -1416,8 +1411,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "gcc-4.2": No such file or directory at ./configure line 708.
-Can't exec "gcc-4.2": No such file or directory at ./configure line 753.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 704.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 749.
 
 
 
@@ -1597,8 +1592,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "cl": No such file or directory at ./configure line 708.
-Can't exec "cl": No such file or directory at ./configure line 753.
+Can't exec "cl": No such file or directory at ./configure line 704.
+Can't exec "cl": No such file or directory at ./configure line 749.
 
 
 
@@ -2441,8 +2436,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 827.
-Use of uninitialized value $v in scalar chomp at ./configure line 828.
+Can't exec "sw_vers": No such file or directory at ./configure line 823.
+Use of uninitialized value $v in scalar chomp at ./configure line 824.
 
 
 
@@ -2532,8 +2527,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 827.
-Use of uninitialized value $v in scalar chomp at ./configure line 828.
+Can't exec "sw_vers": No such file or directory at ./configure line 823.
+Use of uninitialized value $v in scalar chomp at ./configure line 824.
 
 
 
@@ -3221,18 +3216,7 @@ clean:
 
 
 
-=== TEST 39: --with-luajit & --with-luajit=PATH
---- cmd: ./configure --with-luajit=/tmp/luajit --with-luajit
---- out
-platform: linux (linux)
-
---- err
---with-luajit and --with-luajit=DIR are mutually exclusive.
---- exit: 2
-
-
-
-=== TEST 40: ./configure with -jN
+=== TEST 39: ./configure with -jN
 --- cmd: ./configure --dry-run -j10
 --- out
 platform: linux (linux)
@@ -3320,7 +3304,7 @@ clean:
 
 
 
-=== TEST 41: --with-luajit & -jN
+=== TEST 40: --with-luajit & -jN
 --- cmd: ./configure --with-luajit --dry-run -j5
 --- out
 platform: linux (linux)
@@ -3408,7 +3392,7 @@ clean:
 
 
 
-=== TEST 42: relative path as the --add-module option's value
+=== TEST 41: relative path as the --add-module option's value
 --- cmd: ./configure --add-module=/path/to/some/module --add-module=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -3496,7 +3480,7 @@ clean:
 
 
 
-=== TEST 43: relative path as the --with-openssl option's value
+=== TEST 42: relative path as the --with-openssl option's value
 --- cmd: ./configure --with-openssl=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -3584,7 +3568,7 @@ clean:
 
 
 
-=== TEST 44: --without-lua_resty_memcached
+=== TEST 43: --without-lua_resty_memcached
 --- cmd: ./configure --dry-run --without-lua_resty_memcached
 --- out
 platform: linux (linux)
@@ -3671,7 +3655,7 @@ clean:
 
 
 
-=== TEST 45: --without-lua_resty_redis
+=== TEST 44: --without-lua_resty_redis
 --- cmd: ./configure --dry-run --without-lua_resty_redis
 --- out
 platform: linux (linux)
@@ -3758,7 +3742,7 @@ clean:
 
 
 
-=== TEST 46: --with-luajit-xcflags
+=== TEST 45: --with-luajit-xcflags
 --- cmd: ./configure --with-luajit --with-luajit-xcflags='-DLUAJIT_USE_VALGRIND' --dry-run
 --- out
 platform: linux (linux)
@@ -3846,7 +3830,7 @@ clean:
 
 
 
-=== TEST 47: --with-debug & luajit & --with-luajit-xcflags
+=== TEST 46: --with-debug & luajit & --with-luajit-xcflags
 --- cmd: ./configure --with-luajit --with-debug --dry-run --with-luajit-xcflags='-DLUAJIT_USE_VALGRIND'
 --- out
 platform: linux (linux)
@@ -3935,7 +3919,7 @@ clean:
 
 
 
-=== TEST 48: relative path as the --with-pcre option's value
+=== TEST 47: relative path as the --with-pcre option's value
 --- cmd: ./configure --with-pcre=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -4023,7 +4007,7 @@ clean:
 
 
 
-=== TEST 49: relative path as the --with-zlib option's value
+=== TEST 48: relative path as the --with-zlib option's value
 --- cmd: ./configure --with-zlib=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -4111,7 +4095,7 @@ clean:
 
 
 
-=== TEST 50: relative path as the --with-md5 option's value
+=== TEST 49: relative path as the --with-md5 option's value
 --- cmd: ./configure --with-md5=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -4199,7 +4183,7 @@ clean:
 
 
 
-=== TEST 51: relative path as the --with-sha1 option's value
+=== TEST 50: relative path as the --with-sha1 option's value
 --- cmd: ./configure --with-sha1=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -4287,7 +4271,7 @@ clean:
 
 
 
-=== TEST 52: relative path as the --with-libatomic option's value
+=== TEST 51: relative path as the --with-libatomic option's value
 --- cmd: ./configure --with-libatomic=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -4375,7 +4359,7 @@ clean:
 
 
 
-=== TEST 53: --without-lua_resty_dns
+=== TEST 52: --without-lua_resty_dns
 --- cmd: ./configure --dry-run --without-lua_resty_dns
 --- out
 platform: linux (linux)
@@ -4462,7 +4446,7 @@ clean:
 
 
 
-=== TEST 54: --prefix (relative path: "."), lua51
+=== TEST 53: --prefix (relative path: "."), lua51
 --- cmd: ./configure --prefix=. --dry-run
 --- out
 platform: linux (linux)
@@ -4552,7 +4536,7 @@ clean:
 
 
 
-=== TEST 55: --prefix (relative path: "."), luajit
+=== TEST 54: --prefix (relative path: "."), luajit
 --- cmd: ./configure --prefix=. --dry-run
 --- out
 platform: linux (linux)
@@ -4642,7 +4626,7 @@ clean:
 
 
 
-=== TEST 56: --prefix (relative path: ""), luajit
+=== TEST 55: --prefix (relative path: ""), luajit
 --- cmd: ./configure --prefix= --dry-run
 --- out
 platform: linux (linux)
@@ -4732,7 +4716,7 @@ clean:
 
 
 
-=== TEST 57: MSYS platform
+=== TEST 56: MSYS platform
 --- cmd: ./configure --prefix= --platform=msys --dry-run
 --- out
 platform: msys (msys)
@@ -4820,7 +4804,7 @@ clean:
 
 
 
-=== TEST 58: --with-pcre-opt='foo bar'
+=== TEST 57: --with-pcre-opt='foo bar'
 --- cmd: ./configure --dry-run --with-pcre-opt='-foo -bar' --with-zlib-opt="hello, '\world"
 --- out
 platform: linux (linux)
@@ -4908,7 +4892,7 @@ clean:
 
 
 
-=== TEST 59: --with-luajit-xcflags lua 5.2 compat
+=== TEST 58: --with-luajit-xcflags lua 5.2 compat
 --- cmd: ./configure --with-luajit-xcflags='-DLUAJIT_ENABLE_LUA52COMPAT' --dry-run
 --- out
 platform: linux (linux)
@@ -4996,7 +4980,7 @@ clean:
 
 
 
-=== TEST 60: --without-luajit-lua52
+=== TEST 59: --without-luajit-lua52
 --- cmd: ./configure --without-luajit-lua52 --dry-run
 --- out
 platform: linux (linux)
@@ -5084,7 +5068,7 @@ clean:
 
 
 
-=== TEST 61: --with-luajit-xcflags disable gc64
+=== TEST 60: --with-luajit-xcflags disable gc64
 --- cmd: ./configure --with-luajit-xcflags='-DLUAJIT_DISABLE_GC64' --dry-run
 --- out
 platform: linux (linux)
@@ -5172,7 +5156,7 @@ clean:
 
 
 
-=== TEST 62: --without-luajit-gc64
+=== TEST 61: --without-luajit-gc64
 --- cmd: ./configure --without-luajit-gc64 --dry-run
 --- out
 platform: linux (linux)
@@ -5260,7 +5244,7 @@ clean:
 
 
 
-=== TEST 63: --with-luajit-xcflags gc64 & --without-luajit-gc64
+=== TEST 62: --with-luajit-xcflags gc64 & --without-luajit-gc64
 --- cmd: ./configure --with-luajit-xcflags='-DLUAJIT_DISABLE_GC64' --without-luajit-gc64 --dry-run
 --- out
 platform: linux (linux)
@@ -5348,7 +5332,7 @@ clean:
 
 
 
-=== TEST 64: --sbin-path (absolute)
+=== TEST 63: --sbin-path (absolute)
 --- cmd: ./configure --sbin-path=/opt/blah/nginx --dry-run
 --- out
 platform: linux (linux)
@@ -5436,7 +5420,7 @@ clean:
 
 
 
-=== TEST 65: --sbin-path (relative)
+=== TEST 64: --sbin-path (relative)
 --- cmd: ./configure --sbin-path=../bin/nginx --dry-run
 --- out
 platform: linux (linux)
@@ -5524,7 +5508,7 @@ clean:
 
 
 
-=== TEST 66: --without-http_lua_upstream_module (on Linux)
+=== TEST 65: --without-http_lua_upstream_module (on Linux)
 --- cmd: ./configure --dry-run --without-http_lua_upstream_module
 --- out
 platform: linux (linux)
@@ -5611,7 +5595,7 @@ clean:
 
 
 
-=== TEST 67: --without-http_lua_module & --without-stream_lua_module
+=== TEST 66: --without-http_lua_module & --without-stream_lua_module
 --- cmd: ./configure --without-http_lua_module --without-stream_lua_module --dry-run
 --- out
 platform: linux (linux)
@@ -5665,7 +5649,7 @@ clean:
 
 
 
-=== TEST 68: relative path as the --add-dynamic-module option's value
+=== TEST 67: relative path as the --add-dynamic-module option's value
 --- cmd: ./configure --add-dynamic-module=/path/to/some/module --add-dynamic-module=../some/module/ --dry-run
 --- out
 platform: linux (linux)
@@ -5753,7 +5737,7 @@ clean:
 
 
 
-=== TEST 69: --without-stream_ssl_module and --without-http_ssl_module are respected
+=== TEST 68: --without-stream_ssl_module and --without-http_ssl_module are respected
 --- cmd: ./configure --without-http_ssl_module --without-stream_ssl_module --dry-run
 --- out
 platform: linux (linux)
@@ -5796,7 +5780,7 @@ Type the following commands to build and install:
 
 
 
-=== TEST 70: --without-stream_ssl_module and --with-stream_ssl_module specified at the same time causes errors
+=== TEST 69: --without-stream_ssl_module and --with-stream_ssl_module specified at the same time causes errors
 --- cmd: ./configure --with-stream_ssl_module --without-stream_ssl_module --dry-run
 --- out
 platform: linux (linux)
@@ -5807,7 +5791,7 @@ platform: linux (linux)
 
 
 
-=== TEST 71: --with-luajit-ldflags
+=== TEST 70: --with-luajit-ldflags
 --- cmd: ./configure --with-luajit --with-luajit-ldflags='-Wl,-rpath,/tmp/blah/foo' --dry-run
 --- out
 platform: linux (linux)
@@ -5892,4 +5876,3 @@ install: all
 
 clean:
 	rm -rf build *.exe *.dll openresty-*
-

--- a/t/000-sanity.t
+++ b/t/000-sanity.t
@@ -1416,8 +1416,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "gcc-4.2": No such file or directory at ./configure line 710.
-Can't exec "gcc-4.2": No such file or directory at ./configure line 755.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 708.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 753.
 
 
 
@@ -1597,8 +1597,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "cl": No such file or directory at ./configure line 710.
-Can't exec "cl": No such file or directory at ./configure line 755.
+Can't exec "cl": No such file or directory at ./configure line 708.
+Can't exec "cl": No such file or directory at ./configure line 753.
 
 
 
@@ -2441,8 +2441,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 829.
-Use of uninitialized value $v in scalar chomp at ./configure line 830.
+Can't exec "sw_vers": No such file or directory at ./configure line 827.
+Use of uninitialized value $v in scalar chomp at ./configure line 828.
 
 
 
@@ -2532,8 +2532,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 829.
-Use of uninitialized value $v in scalar chomp at ./configure line 830.
+Can't exec "sw_vers": No such file or directory at ./configure line 827.
+Use of uninitialized value $v in scalar chomp at ./configure line 828.
 
 
 

--- a/t/000-sanity.t
+++ b/t/000-sanity.t
@@ -43,6 +43,7 @@ __DATA__
   --without-http_rds_csv_module      disable ngx_http_rds_csv_module
   --without-stream_lua_module        disable ngx_stream_lua_module
   --without-ngx_devel_kit_module     disable ngx_devel_kit_module
+  --without-stream                   disable TCP/UDP proxy module
   --without-http_ssl_module          disable ngx_http_ssl_module
   --without-stream_ssl_module        disable ngx_stream_ssl_module
 
@@ -100,7 +101,7 @@ Options directly inherited from nginx
                                      worker processes
 
   --build=NAME                       set build name
-  --builddir=DIR                     set the build directory
+  --builddir=DIR                     set build directory
 
   --with-select_module               enable select module
   --without-select_module            disable select module
@@ -111,6 +112,7 @@ Options directly inherited from nginx
 
   --with-file-aio                    enable file AIO support
 
+  --with-http_ssl_module             enable ngx_http_ssl_module (default on)
   --with-http_v2_module              enable ngx_http_v2_module
   --with-http_realip_module          enable ngx_http_realip_module
   --with-http_addition_module        enable ngx_http_addition_module
@@ -140,6 +142,7 @@ Options directly inherited from nginx
   --without-http_userid_module       disable ngx_http_userid_module
   --without-http_access_module       disable ngx_http_access_module
   --without-http_auth_basic_module   disable ngx_http_auth_basic_module
+  --without-http_mirror_module       disable ngx_http_mirror_module
   --without-http_autoindex_module    disable ngx_http_autoindex_module
   --without-http_geo_module          disable ngx_http_geo_module
   --without-http_map_module          disable ngx_http_map_module
@@ -150,6 +153,7 @@ Options directly inherited from nginx
   --without-http_fastcgi_module      disable ngx_http_fastcgi_module
   --without-http_uwsgi_module        disable ngx_http_uwsgi_module
   --without-http_scgi_module         disable ngx_http_scgi_module
+  --without-http_grpc_module         disable ngx_http_grpc_module
   --without-http_memcached_module    disable ngx_http_memcached_module
   --without-http_limit_conn_module   disable ngx_http_limit_conn_module
   --without-http_limit_req_module    disable ngx_http_limit_req_module
@@ -161,11 +165,13 @@ Options directly inherited from nginx
                                      disable ngx_http_upstream_ip_hash_module
   --without-http_upstream_least_conn_module
                                      disable ngx_http_upstream_least_conn_module
+  --without-http_upstream_random_module
+                                     disable ngx_http_upstream_random_module
   --without-http_upstream_keepalive_module
                                      disable ngx_http_upstream_keepalive_module
-
   --without-http_upstream_zone_module
                                      disable ngx_http_upstream_zone_module
+
   --with-http_perl_module            enable ngx_http_perl_module
   --with-http_perl_module=dynamic    enable dynamic ngx_http_perl_module
   --with-perl_modules_path=PATH      set Perl modules path
@@ -193,9 +199,6 @@ Options directly inherited from nginx
   --without-mail_imap_module         disable ngx_mail_imap_module
   --without-mail_smtp_module         disable ngx_mail_smtp_module
 
-  --without-stream                   disable TCP/UDP proxy module
-  --without-stream_ssl_module        disable ngx_stream_ssl_module
-
   --with-stream                      enable TCP/UDP proxy module (default on)
   --with-stream=dynamic              enable dynamic TCP/UDP proxy module
   --with-stream_ssl_module           enable ngx_stream_ssl_module (default on)
@@ -214,6 +217,8 @@ Options directly inherited from nginx
                                      disable ngx_stream_upstream_hash_module
   --without-stream_upstream_least_conn_module
                                      disable ngx_stream_upstream_least_conn_module
+  --without-stream_upstream_random_module
+                                     disable ngx_stream_upstream_random_module
   --without-stream_upstream_zone_module
                                      disable ngx_stream_upstream_zone_module
 
@@ -236,8 +241,7 @@ Options directly inherited from nginx
   --without-pcre                     disable PCRE library usage
   --with-pcre                        force PCRE library usage
   --with-pcre=DIR                    set path to PCRE library sources
-  --with-pcre-opt=OPTIONS            set additional make options for PCRE
-  --with-pcre-conf-opt=OPTIONS       set additional configure options for PCRE
+  --with-pcre-opt=OPTIONS            set additional build options for PCRE
   --with-pcre-jit                    build PCRE with JIT compilation support
 
   --with-zlib=DIR                    set path to zlib library sources
@@ -827,6 +831,7 @@ clean:
   --without-http_rds_csv_module      disable ngx_http_rds_csv_module
   --without-stream_lua_module        disable ngx_stream_lua_module
   --without-ngx_devel_kit_module     disable ngx_devel_kit_module
+  --without-stream                   disable TCP/UDP proxy module
   --without-http_ssl_module          disable ngx_http_ssl_module
   --without-stream_ssl_module        disable ngx_stream_ssl_module
 
@@ -884,7 +889,7 @@ Options directly inherited from nginx
                                      worker processes
 
   --build=NAME                       set build name
-  --builddir=DIR                     set the build directory
+  --builddir=DIR                     set build directory
 
   --with-select_module               enable select module
   --without-select_module            disable select module
@@ -895,6 +900,7 @@ Options directly inherited from nginx
 
   --with-file-aio                    enable file AIO support
 
+  --with-http_ssl_module             enable ngx_http_ssl_module (default on)
   --with-http_v2_module              enable ngx_http_v2_module
   --with-http_realip_module          enable ngx_http_realip_module
   --with-http_addition_module        enable ngx_http_addition_module
@@ -924,6 +930,7 @@ Options directly inherited from nginx
   --without-http_userid_module       disable ngx_http_userid_module
   --without-http_access_module       disable ngx_http_access_module
   --without-http_auth_basic_module   disable ngx_http_auth_basic_module
+  --without-http_mirror_module       disable ngx_http_mirror_module
   --without-http_autoindex_module    disable ngx_http_autoindex_module
   --without-http_geo_module          disable ngx_http_geo_module
   --without-http_map_module          disable ngx_http_map_module
@@ -934,6 +941,7 @@ Options directly inherited from nginx
   --without-http_fastcgi_module      disable ngx_http_fastcgi_module
   --without-http_uwsgi_module        disable ngx_http_uwsgi_module
   --without-http_scgi_module         disable ngx_http_scgi_module
+  --without-http_grpc_module         disable ngx_http_grpc_module
   --without-http_memcached_module    disable ngx_http_memcached_module
   --without-http_limit_conn_module   disable ngx_http_limit_conn_module
   --without-http_limit_req_module    disable ngx_http_limit_req_module
@@ -945,11 +953,13 @@ Options directly inherited from nginx
                                      disable ngx_http_upstream_ip_hash_module
   --without-http_upstream_least_conn_module
                                      disable ngx_http_upstream_least_conn_module
+  --without-http_upstream_random_module
+                                     disable ngx_http_upstream_random_module
   --without-http_upstream_keepalive_module
                                      disable ngx_http_upstream_keepalive_module
-
   --without-http_upstream_zone_module
                                      disable ngx_http_upstream_zone_module
+
   --with-http_perl_module            enable ngx_http_perl_module
   --with-http_perl_module=dynamic    enable dynamic ngx_http_perl_module
   --with-perl_modules_path=PATH      set Perl modules path
@@ -977,9 +987,6 @@ Options directly inherited from nginx
   --without-mail_imap_module         disable ngx_mail_imap_module
   --without-mail_smtp_module         disable ngx_mail_smtp_module
 
-  --without-stream                   disable TCP/UDP proxy module
-  --without-stream_ssl_module        disable ngx_stream_ssl_module
-
   --with-stream                      enable TCP/UDP proxy module (default on)
   --with-stream=dynamic              enable dynamic TCP/UDP proxy module
   --with-stream_ssl_module           enable ngx_stream_ssl_module (default on)
@@ -998,6 +1005,8 @@ Options directly inherited from nginx
                                      disable ngx_stream_upstream_hash_module
   --without-stream_upstream_least_conn_module
                                      disable ngx_stream_upstream_least_conn_module
+  --without-stream_upstream_random_module
+                                     disable ngx_stream_upstream_random_module
   --without-stream_upstream_zone_module
                                      disable ngx_stream_upstream_zone_module
 
@@ -1020,8 +1029,7 @@ Options directly inherited from nginx
   --without-pcre                     disable PCRE library usage
   --with-pcre                        force PCRE library usage
   --with-pcre=DIR                    set path to PCRE library sources
-  --with-pcre-opt=OPTIONS            set additional make options for PCRE
-  --with-pcre-conf-opt=OPTIONS       set additional configure options for PCRE
+  --with-pcre-opt=OPTIONS            set additional build options for PCRE
   --with-pcre-jit                    build PCRE with JIT compilation support
 
   --with-zlib=DIR                    set path to zlib library sources
@@ -1038,6 +1046,7 @@ Options directly inherited from nginx
 
   --dry-run                          dry running the configure, for testing only
   --platform=PLATFORM                forcibly specify a platform name, for testing only
+
 
 
 

--- a/util/configure
+++ b/util/configure
@@ -1402,6 +1402,7 @@ _EOC_
 
     $msg .= <<'_EOC_';
   --without-ngx_devel_kit_module     disable ngx_devel_kit_module
+  --without-stream                   disable TCP/UDP proxy module
   --without-http_ssl_module          disable ngx_http_ssl_module
   --without-stream_ssl_module        disable ngx_stream_ssl_module
 
@@ -1461,7 +1462,7 @@ Options directly inherited from nginx
                                      worker processes
 
   --build=NAME                       set build name
-  --builddir=DIR                     set the build directory
+  --builddir=DIR                     set build directory
 
   --with-select_module               enable select module
   --without-select_module            disable select module
@@ -1472,6 +1473,7 @@ Options directly inherited from nginx
 
   --with-file-aio                    enable file AIO support
 
+  --with-http_ssl_module             enable ngx_http_ssl_module (default on)
   --with-http_v2_module              enable ngx_http_v2_module
   --with-http_realip_module          enable ngx_http_realip_module
   --with-http_addition_module        enable ngx_http_addition_module
@@ -1501,6 +1503,7 @@ Options directly inherited from nginx
   --without-http_userid_module       disable ngx_http_userid_module
   --without-http_access_module       disable ngx_http_access_module
   --without-http_auth_basic_module   disable ngx_http_auth_basic_module
+  --without-http_mirror_module       disable ngx_http_mirror_module
   --without-http_autoindex_module    disable ngx_http_autoindex_module
   --without-http_geo_module          disable ngx_http_geo_module
   --without-http_map_module          disable ngx_http_map_module
@@ -1511,6 +1514,7 @@ Options directly inherited from nginx
   --without-http_fastcgi_module      disable ngx_http_fastcgi_module
   --without-http_uwsgi_module        disable ngx_http_uwsgi_module
   --without-http_scgi_module         disable ngx_http_scgi_module
+  --without-http_grpc_module         disable ngx_http_grpc_module
   --without-http_memcached_module    disable ngx_http_memcached_module
   --without-http_limit_conn_module   disable ngx_http_limit_conn_module
   --without-http_limit_req_module    disable ngx_http_limit_req_module
@@ -1522,11 +1526,13 @@ Options directly inherited from nginx
                                      disable ngx_http_upstream_ip_hash_module
   --without-http_upstream_least_conn_module
                                      disable ngx_http_upstream_least_conn_module
+  --without-http_upstream_random_module
+                                     disable ngx_http_upstream_random_module
   --without-http_upstream_keepalive_module
                                      disable ngx_http_upstream_keepalive_module
-
   --without-http_upstream_zone_module
                                      disable ngx_http_upstream_zone_module
+
   --with-http_perl_module            enable ngx_http_perl_module
   --with-http_perl_module=dynamic    enable dynamic ngx_http_perl_module
   --with-perl_modules_path=PATH      set Perl modules path
@@ -1554,9 +1560,6 @@ Options directly inherited from nginx
   --without-mail_imap_module         disable ngx_mail_imap_module
   --without-mail_smtp_module         disable ngx_mail_smtp_module
 
-  --without-stream                   disable TCP/UDP proxy module
-  --without-stream_ssl_module        disable ngx_stream_ssl_module
-
   --with-stream                      enable TCP/UDP proxy module (default on)
   --with-stream=dynamic              enable dynamic TCP/UDP proxy module
   --with-stream_ssl_module           enable ngx_stream_ssl_module (default on)
@@ -1575,6 +1578,8 @@ Options directly inherited from nginx
                                      disable ngx_stream_upstream_hash_module
   --without-stream_upstream_least_conn_module
                                      disable ngx_stream_upstream_least_conn_module
+  --without-stream_upstream_random_module
+                                     disable ngx_stream_upstream_random_module
   --without-stream_upstream_zone_module
                                      disable ngx_stream_upstream_zone_module
 
@@ -1597,8 +1602,7 @@ Options directly inherited from nginx
   --without-pcre                     disable PCRE library usage
   --with-pcre                        force PCRE library usage
   --with-pcre=DIR                    set path to PCRE library sources
-  --with-pcre-opt=OPTIONS            set additional make options for PCRE
-  --with-pcre-conf-opt=OPTIONS       set additional configure options for PCRE
+  --with-pcre-opt=OPTIONS            set additional build options for PCRE
   --with-pcre-jit                    build PCRE with JIT compilation support
 
   --with-zlib=DIR                    set path to zlib library sources

--- a/util/configure
+++ b/util/configure
@@ -555,9 +555,7 @@ _END_
         push @ngx_opts, '--with-stream_ssl_preread_module';
     }
 
-    if (!$opts->{lua}
-        && !$opts->{lua_path}
-        && (!$opts->{no_http_lua} || !$opts->{no_stream_lua})
+    if ((!$opts->{no_http_lua} || !$opts->{no_stream_lua})
         && !$opts->{luajit_path})
     {
         #warn "HIT!";
@@ -902,64 +900,9 @@ int main(void) {
         }
 
         cd '..';
-
-    } elsif ($opts->{lua_path}) {
-        my $lua_prefix = $opts->{lua_path};
-        env LUA_LIB => File::Spec->catfile($lua_prefix, "lib");
-        env LUA_INC => File::Spec->catfile($lua_prefix, "include");
-
-        push @ngx_rpaths, File::Spec->catfile($lua_prefix, "lib");
-
-    } elsif ($opts->{lua}) {
-        # build stdandard lua
-
-        my $lua_src = auto_complete 'lua';
-
-        if (!defined $lua_src) {
-            die "No lua5 found";
-        }
-
-        my $lua_prefix = File::Spec->catfile($prefix, "lua");
-        my $lua_root = File::Spec->rel2abs("lua-root");
-
-        if (-d $lua_root) {
-            shell "rm -rf $lua_root";
-        }
-
-        mkdir $lua_root or
-            die "create create directory lua-root: $!\n";
-
-        cd $lua_src;
-
-        my $extra_opts = '';
-        if (defined $cc) {
-            $extra_opts .= " CC='$cc'";
-        }
-
-        if (defined $cores) {
-            shell "${make} -j$cores$extra_opts $platform", $dry_run;
-        } else {
-            shell "${make}$extra_opts $platform", $dry_run;
-        }
-
-        my $install_top = File::Spec->catfile($lua_root, $lua_prefix);
-        shell "${make} install$extra_opts INSTALL_TOP=$install_top/", $dry_run;
-
-        env LUA_LIB => File::Spec->catfile($lua_root, $lua_prefix, "lib");
-        env LUA_INC => File::Spec->catfile($lua_root, $lua_prefix, "include");
-
-        push @make_cmds,
-            "cd $root_dir/build/$lua_src && \$(MAKE)$extra_opts $platform";
-
-        push @make_install_cmds, "cd $root_dir/build/$lua_src && "
-            . "\$(MAKE) install$extra_opts INSTALL_TOP=\$(DESTDIR)$lua_prefix";
-
-        cd '..';
     }
 
-    if ($opts->{lua} || $opts->{lua_path}
-        || $opts->{luajit} || $opts->{luajit_path})
-    {
+    if ($opts->{luajit} || $opts->{luajit_path}) {
         # build lua modules
 
         $lualib_prefix = File::Spec->catfile($prefix, "lualib");

--- a/util/configure
+++ b/util/configure
@@ -263,7 +263,7 @@ for my $opt (@ARGV) {
         $resty_opts{"$1"} = 1;
 
     } elsif ($opt eq '--with-luajit') {
-        $resty_opts{luajit} = 1;
+        # NOP for backwards-compatibility (the default)
 
     } elsif ($opt =~ /^--with-luajit=(.*)/) {
         $resty_opts{luajit_path} = $1;
@@ -563,10 +563,6 @@ _END_
     }
 
     #die "luajit: ", $opts->{luajit};
-
-    if ($opts->{luajit} && $opts->{luajit_path}) {
-        die "--with-luajit and --with-luajit=DIR are mutually exclusive.\n";
-    }
 
     if ($opts->{no_http_ssl} && $opts->{http_ssl}) {
         die "--with-http_ssl_module conflicts with --without-http_ssl_module.",
@@ -1296,8 +1292,7 @@ sub usage ($) {
 
   --with-no-pool-patch               enable the no-pool patch for debugging memory issues
 
-  -jN                                pass -jN option to make while building the bundled
-                                     Lua 5.1 interpreter or LuaJIT 2.1
+  -jN                                pass -jN option to make while building LuaJIT 2.1
 
 _EOC_
 
@@ -1377,12 +1372,11 @@ _EOC_
   --without-lua_resty_shell          disable the lua-resty-shell library
   --without-lua_resty_core           disable the lua-resty-core library
 
-  --with-luajit                      enable and build the bundled LuaJIT 2.1 (the default)
   --with-luajit=DIR                  use the external LuaJIT 2.1 installation specified by DIR
   --with-luajit-xcflags=FLAGS        Specify extra C compiler flags for LuaJIT 2.1
   --with-luajit-ldflags=FLAGS        Specify extra C linker flags for LuaJIT 2.1
   --without-luajit-lua52             Turns off the LuaJIT extensions from Lua 5.2 that may break
-                                     backward compatibility.
+                                     backward compatibility
   --without-luajit-gc64              Turns off the LuaJIT GC64 mode (which is enabled by default
                                      on x86_64)
 


### PR DESCRIPTION

* configure: updated options inherited from NGINX 1.17.8:
  * removed duplicated `--without-stream_ssl_module` option
  * removed obsolete `--with-pcre-conf-opt` option
  * added "(default on) description to `--with-http_ssl_module` option
  * moved `--without-stream` option to OpenResty's section
* configure: removed dead code since PUC-Lua isn't supported anymore.
* configure: removed outdated '--with-luajit' option (always the default). 

> I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
