### PR TITLE
feature: --ngx_prefix for specific prefix for nginx

### DIFF
--- a/t/000-sanity.t
+++ b/t/000-sanity.t
@@ -1401,7 +1401,7 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "gcc-4.2": No such file or directory at ./configure line 719.
+Can't exec "gcc-4.2": No such file or directory at ./configure line 724.
 
 
 
@@ -1579,7 +1579,7 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "cl": No such file or directory at ./configure line 719.
+Can't exec "cl": No such file or directory at ./configure line 724.
 
 
 
@@ -2323,8 +2323,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 793.
-Use of uninitialized value $v in scalar chomp at ./configure line 794.
+Can't exec "sw_vers": No such file or directory at ./configure line 798.
+Use of uninitialized value $v in scalar chomp at ./configure line 799.
 
 
 
@@ -2413,8 +2413,8 @@ install: all
 clean:
 	rm -rf build *.exe *.dll openresty-*
 --- err
-Can't exec "sw_vers": No such file or directory at ./configure line 793.
-Use of uninitialized value $v in scalar chomp at ./configure line 794.
+Can't exec "sw_vers": No such file or directory at ./configure line 798.
+Use of uninitialized value $v in scalar chomp at ./configure line 799.
 
 
 

--- a/util/configure
+++ b/util/configure
@@ -124,6 +124,7 @@ my $with_resty_mods_regex;
 }
 
 my $prefix = '/usr/local/openresty';
+my $ngx_prefix;
 my $ngx_sbin;
 my %resty_opts;
 my $dry_run;
@@ -171,6 +172,9 @@ for my $opt (@ARGV) {
         if ($prefix eq '') {
             $prefix = '.';
         }
+
+    } elsif ($opt =~ /^--ngx-prefix=(.*)/) {
+        $ngx_prefix = $1;
 
     } elsif ($opt eq '--without-lua51') {
         die "ERROR: --without-lua51 is no longer supported.\n";
@@ -381,11 +385,12 @@ if ($platform eq 'msys') {
 
 print "platform: $platform ($OS)\n";
 
-my $ngx_prefix;
-if ($platform eq 'msys') {
-    $ngx_prefix = "$prefix";
-} else {
-    $ngx_prefix = "$prefix/nginx";
+if (!$ngx_prefix) {
+    if ($platform eq 'msys') {
+        $ngx_prefix = "$prefix";
+    } else {
+        $ngx_prefix = "$prefix/nginx";
+    }
 }
 
 my $postamble = '';


### PR DESCRIPTION
Sometime we can to use the binary of Openresty instead of the binary of Nginx, but we have many old config which the path is related to Nginx's prefix. So we need specific the prefix of Nginx, but not `$prefix_of_openresty/nginx`.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
