### PR TITLE
build-win32.sh: removed redundant configuration '--with-ipv6'.

### DIFF
--- a/util/build-win32.sh
+++ b/util/build-win32.sh
@@ -29,7 +29,6 @@ cd ../../..
 
 ./configure \
     --with-cc=gcc \
-    --with-ipv6 \
     --prefix= \
     --with-cc-opt='-DFD_SETSIZE=1024' \
     --sbin-path=nginx.exe \


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10736359/103627958-4314b600-4f79-11eb-900b-9afcd7f15fd1.png)


I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

