### PR TITLE
bugfix: applied the patch for security advisory to NGINX cores >= 0.6.18 and <= 1.20.0 (CVE-2021-23017).

### DIFF
--- a/patches/patch.2021.resolver.txt
+++ b/patches/patch.2021.resolver.txt
@@ -1,0 +1,23 @@
+diff --git src/core/ngx_resolver.c src/core/ngx_resolver.c
+--- src/core/ngx_resolver.c
++++ src/core/ngx_resolver.c
+@@ -4008,15 +4008,15 @@ done:
+             n = *src++;
+ 
+         } else {
++            if (dst != name->data) {
++                *dst++ = '.';
++            }
++
+             ngx_strlow(dst, src, n);
+             dst += n;
+             src += n;
+ 
+             n = *src++;
+-
+-            if (n != 0) {
+-                *dst++ = '.';
+-            }
+         }
+ 
+         if (n == 0) {

--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -469,6 +469,16 @@ else
     echo
 fi
 
+answer=`$root/util/ver-ge "$main_ver" 0.6.18`
+if [ "$answer" = "Y" ]; then
+    answer=`$root/util/ver-ge "$main_ver" 1.20.1`
+    if [ "$answer" = "N" ]; then
+        echo "$info_txt applying the patch for nginx security advisory (CVE-2021-23017)"
+        patch -p0 < $root/patches/patch.2021.resolver.txt || exit 1
+        echo
+    fi
+fi
+
 echo "$info_txt applying the upstream_timeout_fields patch for nginx"
 patch -p1 < $root/patches/nginx-$main_ver-upstream_timeout_fields.patch || exit 1
 echo


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.