### PR TITLE
mirror-tarballs: fixed the directory deletion errors.

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -961,7 +961,7 @@ cd $curdir || exit 1
 #find bundle -name '*.markdown' -delete
 #find bundle -name '*.wiki' -delete
 find bundle -name '*~' -delete
-find bundle -name '.*' -delete
+find bundle -name '.*' -exec rm -rv {} +
 find bundle -name '*.orig' -delete
 #find bundle -name '*.yml' -delete
 #find bundle -name '*.ini' -delete


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.