### PR TITLE
bugfix: check if the worker_connections is 0 before privileged agent spawning.

### DIFF
--- a/patches/nginx-1.19.3-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.19.3-privileged_agent_process_connections.patch
@@ -51,3 +51,23 @@ index b1eb322..8e03696 100644
  
      ngx_worker_process_init(cycle, -1);
  
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -442,6 +442,15 @@
+         return;
+     }
+ 
++    /* 0 is an illegal value and may result in a core dump later */
++    if (ccf->privileged_agent_connections == 0) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
++                      "%ui worker_connections are not enough, "
++                      "privileged agent process cannot be spawned",
++                      ccf->privileged_agent_connections);
++        return;
++    }
++
+     ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
+                       "privileged agent process", "privileged agent process",
+                       respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);

--- a/patches/nginx-1.19.3-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.19.3-privileged_agent_process_connections.patch
@@ -62,7 +62,7 @@ index df25f9d..bd259c1 100644
 +    /* 0 is an illegal value and may result in a core dump later */
 +    if (ccf->privileged_agent_connections == 0) {
 +        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
-+                      "%ui worker_connections are not enough, "
++                      "%ui worker_connection is not enough, "
 +                      "privileged agent process cannot be spawned",
 +                      ccf->privileged_agent_connections);
 +        return;

--- a/patches/nginx-1.19.9-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.19.9-privileged_agent_process_connections.patch
@@ -62,7 +62,7 @@ index df25f9d..bd259c1 100644
 +    /* 0 is an illegal value and may result in a core dump later */
 +    if (ccf->privileged_agent_connections == 0) {
 +        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
-+                      "%ui worker_connections are not enough, "
++                      "%ui worker_connection is not enough, "
 +                      "privileged agent process cannot be spawned",
 +                      ccf->privileged_agent_connections);
 +        return;

--- a/patches/nginx-1.19.9-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.19.9-privileged_agent_process_connections.patch
@@ -51,3 +51,23 @@ index df25f9d..bd259c1 100644
  
      ngx_worker_process_init(cycle, -1);
  
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -442,6 +442,15 @@
+         return;
+     }
+ 
++    /* 0 is an illegal value and may result in a core dump later */
++    if (ccf->privileged_agent_connections == 0) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
++                      "%ui worker_connections are not enough, "
++                      "privileged agent process cannot be spawned",
++                      ccf->privileged_agent_connections);
++        return;
++    }
++
+     ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
+                       "privileged agent process", "privileged agent process",
+                       respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);

--- a/patches/nginx-1.21.3-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.21.3-privileged_agent_process_connections.patch
@@ -62,7 +62,7 @@ index df25f9d..bd259c1 100644
 +    /* 0 is an illegal value and may result in a core dump later */
 +    if (ccf->privileged_agent_connections == 0) {
 +        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
-+                      "%ui worker_connections are not enough, "
++                      "%ui worker_connection is not enough, "
 +                      "privileged agent process cannot be spawned",
 +                      ccf->privileged_agent_connections);
 +        return;

--- a/patches/nginx-1.21.3-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.21.3-privileged_agent_process_connections.patch
@@ -51,3 +51,23 @@ index df25f9d..bd259c1 100644
  
      ngx_worker_process_init(cycle, -1);
  
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -442,6 +442,15 @@
+         return;
+     }
+ 
++    /* 0 is an illegal value and may result in a core dump later */
++    if (ccf->privileged_agent_connections == 0) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
++                      "%ui worker_connections are not enough, "
++                      "privileged agent process cannot be spawned",
++                      ccf->privileged_agent_connections);
++        return;
++    }
++
+     ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
+                       "privileged agent process", "privileged agent process",
+                       respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);

--- a/patches/nginx-1.21.4-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.21.4-privileged_agent_process_connections.patch
@@ -62,7 +62,7 @@ index df25f9d..bd259c1 100644
 +    /* 0 is an illegal value and may result in a core dump later */
 +    if (ccf->privileged_agent_connections == 0) {
 +        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
-+                      "%ui worker_connections are not enough, "
++                      "%ui worker_connection is not enough, "
 +                      "privileged agent process cannot be spawned",
 +                      ccf->privileged_agent_connections);
 +        return;

--- a/patches/nginx-1.21.4-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.21.4-privileged_agent_process_connections.patch
@@ -51,3 +51,23 @@ index df25f9d..bd259c1 100644
  
      ngx_worker_process_init(cycle, -1);
  
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -442,6 +442,15 @@
+         return;
+     }
+ 
++    /* 0 is an illegal value and may result in a core dump later */
++    if (ccf->privileged_agent_connections == 0) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
++                      "%ui worker_connections are not enough, "
++                      "privileged agent process cannot be spawned",
++                      ccf->privileged_agent_connections);
++        return;
++    }
++
+     ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
+                       "privileged agent process", "privileged agent process",
+                       respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);


### PR DESCRIPTION
The core dump may occur during initialization

```
       Program terminated with signal SIGSEGV, Segmentation fault.
      #0  0x0000000000441711 in ngx_event_process_init (cycle=0x1e93cc0) at src/event/ngx_event.c:807
      801         i = cycle->connection_n;
      802         next = NULL;
      803
      804         do {
      805             i--;
      806
      807             c[i].data = next;
      #1  0x000000000044abb9 in ngx_worker_process_init (cycle=cycle@entry=0x1e93cc0, worker=worker@entry=-1) at
   src/os/unix/ngx_process_cycle.c:968
```

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.