### PR TITLE
chore: move the cleaning of temporary patches to right place

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -448,8 +448,6 @@ if [ "$answer" = "Y" ]; then
     fi
 fi
 
-rm -f *.patch || exit 1
-
 answer=`$root/util/ver-ge "$main_ver" 1.17.8`
 if [ "$answer" = "Y" ]; then
     answer=`$root/util/ver-ge "$main_ver" 1.21.0`
@@ -514,6 +512,8 @@ echo
 
 cp $root/html/index.html docs/html/ || exit 1
 cp $root/html/50x.html docs/html/ || exit 1
+
+rm -f *.patch || exit 1
 
 cd .. || exit 1
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.


Hello!

There is a `rm -f *.patch || exit 1` in mirrors-tarball,
from the beginng of history, https://github.com/openresty/openresty/blob/baeb020fece352befd83a672de9018d889bb90e5/util/mirror-tarballs

we can conclude that it is used to clean temporary patches like `nginx-$main_ver-server_header.patch`, which will dynamiclly updated by sed from the original patch file.

But when more and more patches get in, don't know why this cleaning line goes int the middle of patch work.
I guess we should keep it after all patches applys to avoid potential  untidy work.

thanks.
