### PR TITLE
Actually run testing on s390x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ _linux-s390x: &linux-s390x
     - export PATH=$OPENRESTY_PREFIX/bin:$OPENRESTY_PREFIX/nginx/sbin:$PATH
     - nginx -V
     - ldd `which nginx`|grep -E 'luajit|ssl|pcre'
+    - prove -I. -r t/
 
 _linux-ppc64le: &linux-ppc64le
   os: linux


### PR DESCRIPTION
This PR makes testsuite run on s390x.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
