### PR TITLE
tests: 002-reuseport-close-unused-fds.t: the order of the logs generated by multiple processes is uncertain.

### DIFF
--- a/t/002-reuseport-close-unused-fds.t
+++ b/t/002-reuseport-close-unused-fds.t
@@ -58,10 +58,13 @@ GET /t
 [error]
 --- grep_error_log eval: qr/\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.\d+:12345/
 --- grep_error_log_out eval
-qr/\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.1:12345
+qr/(\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.1:12345
 \[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.2:12345
 \[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.1:12345
+\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.2:12345)|(\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.1:12345
+\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.1:12345
 \[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.2:12345
+\[debug\] .*? closing unused fd:\d+ listening on 127\.0\.0\.2:12345)
 /
 
 


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
