### PR TITLE
bugfix: clear tag in ngx_buf_t to avoid double free

### DIFF
--- a/patches/nginx-1.21.4-clear_ngx_buf_tag.patch
+++ b/patches/nginx-1.21.4-clear_ngx_buf_tag.patch
@@ -1,0 +1,11 @@
+diff -aNur nginx-1.21.4/src/core/ngx_buf.c nginx-1.21.4-patched/src/core/ngx_buf.c
+--- nginx-1.21.4/src/core/ngx_buf.c	2021-11-05 13:06:14.000000000 +0800
++++ nginx-1.21.4-patched/src/core/ngx_buf.c	2022-10-27 21:45:48.943152558 +0800
+@@ -213,6 +213,8 @@
+             break;
+         }
+ 
++        cl->buf->tag = 0;
++
+         cl->buf->pos = cl->buf->start;
+         cl->buf->last = cl->buf->start;


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

Fix https://github.com/openresty/lua-nginx-module/issues/2110

When the buf get freed in `ngx_chain_update_chains`,  clear the tag to avoid double free in the caller.
The tag is useless after freed, and when the buf get reused later, the caller would assign it the corresponding tag again, so it's safe.
