### PR TITLE
bump nginx to 1.25.4

### DIFF
--- a/patches/nginx-1.25.4-always_enable_cc_feature_tests.patch
+++ b/patches/nginx-1.25.4-always_enable_cc_feature_tests.patch
@@ -1,0 +1,11 @@
+--- nginx-1.25.4/auto/cc/conf	2015-10-30 22:47:50.000000000 +0800
++++ nginx-1.25.4-patched/auto/cc/conf	2015-11-02 12:23:05.385156987 +0800
+@@ -144,7 +144,7 @@ fi
+ CFLAGS="$CFLAGS $NGX_CC_OPT"
+ NGX_TEST_LD_OPT="$NGX_LD_OPT"
+ 
+-if [ "$NGX_PLATFORM" != win32 ]; then
++if [ 1 ]; then
+ 
+     if test -n "$NGX_LD_OPT"; then
+         ngx_feature=--with-ld-opt=\"$NGX_LD_OPT\"

--- a/patches/nginx-1.25.4-balancer_status_code.patch
+++ b/patches/nginx-1.25.4-balancer_status_code.patch
@@ -1,0 +1,72 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index f8d5707d..6efe0047 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -1515,6 +1515,11 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         return;
+     }
+ 
++    if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
++        ngx_http_upstream_finalize_request(r, u, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index 3e714e5b..dfbb25e0 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -427,4 +427,9 @@ extern ngx_conf_bitmask_t  ngx_http_upstream_cache_method_mask[];
+ extern ngx_conf_bitmask_t  ngx_http_upstream_ignore_headers_masks[];
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_HTTP_UPSTREAM_H_INCLUDED_ */
+diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
+index 09d24593..d8b4b584 100644
+--- a/src/stream/ngx_stream.h
++++ b/src/stream/ngx_stream.h
+@@ -27,6 +27,7 @@ typedef struct ngx_stream_session_s  ngx_stream_session_t;
+ 
+ 
+ #define NGX_STREAM_OK                        200
++#define NGX_STREAM_SPECIAL_RESPONSE          300
+ #define NGX_STREAM_BAD_REQUEST               400
+ #define NGX_STREAM_FORBIDDEN                 403
+ #define NGX_STREAM_INTERNAL_SERVER_ERROR     500
+diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
+index 818d7329..329dcdc6 100644
+--- a/src/stream/ngx_stream_proxy_module.c
++++ b/src/stream/ngx_stream_proxy_module.c
+@@ -691,6 +691,11 @@ ngx_stream_proxy_connect(ngx_stream_session_t *s)
+         return;
+     }
+ 
++    if (rc >= NGX_STREAM_SPECIAL_RESPONSE) {
++        ngx_stream_proxy_finalize(s, rc);
++        return;
++    }
++
+     u->state->peer = u->peer.name;
+ 
+     if (rc == NGX_BUSY) {
+diff --git a/src/stream/ngx_stream_upstream.h b/src/stream/ngx_stream_upstream.h
+index 73947f46..21bc0ad7 100644
+--- a/src/stream/ngx_stream_upstream.h
++++ b/src/stream/ngx_stream_upstream.h
+@@ -151,4 +151,9 @@ ngx_stream_upstream_srv_conf_t *ngx_stream_upstream_add(ngx_conf_t *cf,
+ extern ngx_module_t  ngx_stream_upstream_module;
+ 
+ 
++#ifndef HAVE_BALANCER_STATUS_CODE_PATCH
++#define HAVE_BALANCER_STATUS_CODE_PATCH
++#endif
++
++
+ #endif /* _NGX_STREAM_UPSTREAM_H_INCLUDED_ */

--- a/patches/nginx-1.25.4-builtin_error_page_footer.patch
+++ b/patches/nginx-1.25.4-builtin_error_page_footer.patch
@@ -1,0 +1,13 @@
+diff --git a/src/http/ngx_http_special_response.c b/src/http/ngx_http_special_response.c
+index 64e5acd..f5374f6 100644
+--- a/src/http/ngx_http_special_response.c
++++ b/src/http/ngx_http_special_response.c
+@@ -26,7 +26,7 @@ static u_char ngx_http_error_full_tail[] =
+ 
+ 
+ static u_char ngx_http_error_tail[] =
+-"<hr><center>nginx</center>" CRLF
++"<hr><center>openresty</center>" CRLF
+ "</body>" CRLF
+ "</html>" CRLF
+ ;

--- a/patches/nginx-1.25.4-cache_manager_exit.patch
+++ b/patches/nginx-1.25.4-cache_manager_exit.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1383598130 28800
+# Node ID f64218e1ac963337d84092536f588b8e0d99bbaa
+# Parent  dea321e5c0216efccbb23e84bbce7cf3e28f130c
+Cache: gracefully exit the cache manager process.
+
+diff -r dea321e5c021 -r f64218e1ac96 src/os/unix/ngx_process_cycle.c
+--- a/src/os/unix/ngx_process_cycle.c	Thu Oct 31 18:23:49 2013 +0400
++++ b/src/os/unix/ngx_process_cycle.c	Mon Nov 04 12:48:50 2013 -0800
+@@ -1134,7 +1134,7 @@
+ 
+         if (ngx_terminate || ngx_quit) {
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
+-            exit(0);
++            ngx_worker_process_exit(cycle);
+         }
+ 
+         if (ngx_reopen) {

--- a/patches/nginx-1.25.4-daemon_destroy_pool.patch
+++ b/patches/nginx-1.25.4-daemon_destroy_pool.patch
@@ -1,0 +1,12 @@
+diff --git a/src/os/unix/ngx_daemon.c b/src/os/unix/ngx_daemon.c
+index ab672110..f259af31 100644
+--- a/src/os/unix/ngx_daemon.c
++++ b/src/os/unix/ngx_daemon.c
+@@ -23,6 +23,8 @@ ngx_daemon(ngx_log_t *log)
+         break;
+
+     default:
++        /* just to make it ASAN or Valgrind clean */
++        ngx_destroy_pool(ngx_cycle->pool);
+         exit(0);
+     }

--- a/patches/nginx-1.25.4-delayed_posted_events.patch
+++ b/patches/nginx-1.25.4-delayed_posted_events.patch
@@ -1,0 +1,98 @@
+diff --git a/src/event/ngx_event.c b/src/event/ngx_event.c
+index 57af8132..4853945f 100644
+--- a/src/event/ngx_event.c
++++ b/src/event/ngx_event.c
+@@ -196,6 +196,9 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+     ngx_uint_t  flags;
+     ngx_msec_t  timer, delta;
+ 
++    ngx_queue_t     *q;
++    ngx_event_t     *ev;
++
+     if (ngx_timer_resolution) {
+         timer = NGX_TIMER_INFINITE;
+         flags = 0;
+@@ -215,6 +218,13 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+ #endif
+     }
+ 
++    if (!ngx_queue_empty(&ngx_posted_delayed_events)) {
++        ngx_log_debug0(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                       "posted delayed event queue not empty"
++                       " making poll timeout 0");
++        timer = 0;
++    }
++
+     if (ngx_use_accept_mutex) {
+         if (ngx_accept_disabled > 0) {
+             ngx_accept_disabled--;
+@@ -257,6 +267,35 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
+     }
+ 
+     ngx_event_process_posted(cycle, &ngx_posted_events);
++
++    while (!ngx_queue_empty(&ngx_posted_delayed_events)) {
++        q = ngx_queue_head(&ngx_posted_delayed_events);
++
++        ev = ngx_queue_data(q, ngx_event_t, queue);
++        if (ev->delayed) {
++            /* start of newly inserted nodes */
++            for (/* void */;
++                 q != ngx_queue_sentinel(&ngx_posted_delayed_events);
++                 q = ngx_queue_next(q))
++            {
++                ev = ngx_queue_data(q, ngx_event_t, queue);
++                ev->delayed = 0;
++
++                ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                               "skipping delayed posted event %p,"
++                               " till next iteration", ev);
++            }
++
++            break;
++        }
++
++        ngx_log_debug1(NGX_LOG_DEBUG_EVENT, cycle->log, 0,
++                       "delayed posted event %p", ev);
++
++        ngx_delete_posted_event(ev);
++
++        ev->handler(ev);
++    }
+ }
+ 
+ 
+@@ -600,6 +639,7 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+     ngx_queue_init(&ngx_posted_accept_events);
+     ngx_queue_init(&ngx_posted_events);
++    ngx_queue_init(&ngx_posted_delayed_events);
+ 
+     if (ngx_event_timer_init(cycle->log) == NGX_ERROR) {
+         return NGX_ERROR;
+diff --git a/src/event/ngx_event_posted.c b/src/event/ngx_event_posted.c
+index d851f3d1..b6cea009 100644
+--- a/src/event/ngx_event_posted.c
++++ b/src/event/ngx_event_posted.c
+@@ -12,6 +12,7 @@
+ 
+ ngx_queue_t  ngx_posted_accept_events;
+ ngx_queue_t  ngx_posted_events;
++ngx_queue_t  ngx_posted_delayed_events;
+ 
+ 
+ void
+diff --git a/src/event/ngx_event_posted.h b/src/event/ngx_event_posted.h
+index 145d30fe..6c388553 100644
+--- a/src/event/ngx_event_posted.h
++++ b/src/event/ngx_event_posted.h
+@@ -43,6 +43,9 @@ void ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted);
+ 
+ extern ngx_queue_t  ngx_posted_accept_events;
+ extern ngx_queue_t  ngx_posted_events;
++extern ngx_queue_t  ngx_posted_delayed_events;
++
++#define HAVE_POSTED_DELAYED_EVENTS_PATCH
+ 
+ 
+ #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/patches/nginx-1.25.4-hash_overflow.patch
+++ b/patches/nginx-1.25.4-hash_overflow.patch
@@ -1,0 +1,20 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1412276417 25200
+#      Thu Oct 02 12:00:17 2014 -0700
+# Node ID 4032b992f23b054c1a2cfb0be879330d2c6708e5
+# Parent  1ff0f68d9376e3d184d65814a6372856bf65cfcd
+Hash: buffer overflow might happen when exceeding the pre-configured limits.
+
+diff -r 1ff0f68d9376 -r 4032b992f23b src/core/ngx_hash.c
+--- a/src/core/ngx_hash.c	Tue Sep 30 15:50:28 2014 -0700
++++ b/src/core/ngx_hash.c	Thu Oct 02 12:00:17 2014 -0700
+@@ -312,6 +312,8 @@ ngx_hash_init(ngx_hash_init_t *hinit, ng
+         continue;
+     }
+ 
++    size--;
++
+     ngx_log_error(NGX_LOG_WARN, hinit->pool->log, 0,
+                   "could not build optimal %s, you should increase "
+                   "either %s_max_size: %i or %s_bucket_size: %i; "

--- a/patches/nginx-1.25.4-init_cycle_pool_release.patch
+++ b/patches/nginx-1.25.4-init_cycle_pool_release.patch
@@ -1,0 +1,59 @@
+diff -rup nginx-1.25.4/src/core/nginx.c nginx-1.25.4-patched/src/core/nginx.c
+--- nginx-1.25.4/src/core/nginx.c	2017-12-17 00:00:38.136470108 -0800
++++ nginx-1.25.4-patched/src/core/nginx.c	2017-12-16 23:59:51.680958322 -0800
+@@ -186,6 +186,7 @@ static u_char      *ngx_prefix;
+ static u_char      *ngx_conf_file;
+ static u_char      *ngx_conf_params;
+ static char        *ngx_signal;
++ngx_pool_t         *saved_init_cycle_pool = NULL;
+ 
+ 
+ static char **ngx_os_environ;
+@@ -253,6 +254,8 @@ main(int argc, char *const *argv)
+         return 1;
+     }
+ 
++    saved_init_cycle_pool = init_cycle.pool;
++
+     if (ngx_save_argv(&init_cycle, argc, argv) != NGX_OK) {
+         return 1;
+     }
+diff -rup nginx-1.25.4/src/core/ngx_core.h nginx-1.25.4-patched/src/core/ngx_core.h
+--- nginx-1.25.4/src/core/ngx_core.h	2017-10-10 08:22:51.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_core.h	2017-12-16 23:59:51.679958370 -0800
+@@ -108,4 +108,6 @@ void ngx_cpuinfo(void);
+ #define NGX_DISABLE_SYMLINKS_NOTOWNER   2
+ #endif
+ 
++extern ngx_pool_t        *saved_init_cycle_pool;
++
+ #endif /* _NGX_CORE_H_INCLUDED_ */
+diff -rup nginx-1.25.4/src/core/ngx_cycle.c nginx-1.25.4-patched/src/core/ngx_cycle.c
+--- nginx-1.25.4/src/core/ngx_cycle.c	2017-10-10 08:22:51.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_cycle.c	2017-12-16 23:59:51.678958419 -0800
+@@ -748,6 +748,10 @@ old_shm_zone_done:
+ 
+     if (ngx_process == NGX_PROCESS_MASTER || ngx_is_init_cycle(old_cycle)) {
+ 
++        if (ngx_is_init_cycle(old_cycle)) {
++            saved_init_cycle_pool = NULL;
++        }
++
+         ngx_destroy_pool(old_cycle->pool);
+         cycle->old_cycle = NULL;
+ 
+diff -rup nginx-1.25.4/src/os/unix/ngx_process_cycle.c nginx-1.25.4-patched/src/os/unix/ngx_process_cycle.c
+--- nginx-1.25.4/src/os/unix/ngx_process_cycle.c	2017-12-17 00:00:38.142469762 -0800
++++ nginx-1.25.4-patched/src/os/unix/ngx_process_cycle.c	2017-12-16 23:59:51.691957791 -0800
+@@ -687,6 +692,11 @@ ngx_master_process_exit(ngx_cycle_t *cyc
+     ngx_exit_cycle.files_n = ngx_cycle->files_n;
+     ngx_cycle = &ngx_exit_cycle;
+ 
++    if (saved_init_cycle_pool != NULL && saved_init_cycle_pool != cycle->pool) {
++        ngx_destroy_pool(saved_init_cycle_pool);
++        saved_init_cycle_pool = NULL;
++    }
++
+     ngx_destroy_pool(cycle->pool);
+ 
+     exit(0);

--- a/patches/nginx-1.25.4-intercept_error_log.patch
+++ b/patches/nginx-1.25.4-intercept_error_log.patch
@@ -1,0 +1,60 @@
+diff --git a/src/core/ngx_cycle.h b/src/core/ngx_cycle.h
+index c51b7ff..4c335b9 100644
+--- a/src/core/ngx_cycle.h
++++ b/src/core/ngx_cycle.h
+@@ -22,9 +22,14 @@
+ #define NGX_DEBUG_POINTS_ABORT  2
+ 
+ 
++#define HAVE_INTERCEPT_ERROR_LOG_PATCH
++
++
+ typedef struct ngx_shm_zone_s  ngx_shm_zone_t;
+ 
+ typedef ngx_int_t (*ngx_shm_zone_init_pt) (ngx_shm_zone_t *zone, void *data);
++typedef ngx_int_t (*ngx_log_intercept_pt) (ngx_log_t *log, ngx_uint_t level,
++    u_char *buf, size_t len);
+ 
+ struct ngx_shm_zone_s {
+     void                     *data;
+@@ -75,6 +80,10 @@ struct ngx_cycle_s {
+     ngx_str_t                 prefix;
+     ngx_str_t                 lock_file;
+     ngx_str_t                 hostname;
++
++    ngx_log_intercept_pt      intercept_error_log_handler;
++    void                     *intercept_error_log_data;
++    unsigned                  entered_logger;    /* :1 */
+ };
+ 
+ 
+diff --git a/src/core/ngx_log.c b/src/core/ngx_log.c
+index 8e9408d..ed9b11b 100644
+--- a/src/core/ngx_log.c
++++ b/src/core/ngx_log.c
+@@ -112,6 +112,8 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
+     ngx_uint_t   wrote_stderr, debug_connection;
+     u_char       errstr[NGX_MAX_ERROR_STR];
+ 
++    ngx_log_intercept_pt    log_intercept = NULL;
++
+     last = errstr + NGX_MAX_ERROR_STR;
+ 
+     p = ngx_cpymem(errstr, ngx_cached_err_log_time.data,
+@@ -153,6 +155,16 @@ ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
+         p = last - NGX_LINEFEED_SIZE;
+     }
+ 
++    if (ngx_cycle) {
++        log_intercept = ngx_cycle->intercept_error_log_handler;
++    }
++
++    if (log_intercept && !ngx_cycle->entered_logger) {
++        ngx_cycle->entered_logger = 1;
++        log_intercept(log, level, errstr, p - errstr);
++        ngx_cycle->entered_logger = 0;
++    }
++
+     ngx_linefeed(p);
+ 
+     wrote_stderr = 0;

--- a/patches/nginx-1.25.4-larger_max_error_str.patch
+++ b/patches/nginx-1.25.4-larger_max_error_str.patch
@@ -1,0 +1,13 @@
+--- nginx-1.25.4/src/core/ngx_log.h	2013-10-08 05:07:14.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_log.h	2013-12-05 20:35:35.996236720 -0800
+@@ -64,7 +64,9 @@ struct ngx_log_s {
+ };
+ 
+ 
+-#define NGX_MAX_ERROR_STR   2048
++#ifndef NGX_MAX_ERROR_STR
++#define NGX_MAX_ERROR_STR   4096
++#endif
+ 
+ 
+ /*********************************/

--- a/patches/nginx-1.25.4-log_escape_non_ascii.patch
+++ b/patches/nginx-1.25.4-log_escape_non_ascii.patch
@@ -1,0 +1,117 @@
+diff --git a/src/http/modules/ngx_http_log_module.c b/src/http/modules/ngx_http_log_module.c
+index 917ed55f..b769dfd3 100644
+--- a/src/http/modules/ngx_http_log_module.c
++++ b/src/http/modules/ngx_http_log_module.c
+@@ -79,6 +79,8 @@ typedef struct {
+     time_t                      open_file_cache_valid;
+     ngx_uint_t                  open_file_cache_min_uses;
+ 
++    ngx_flag_t                  escape_non_ascii;
++
+     ngx_uint_t                  off;        /* unsigned  off:1 */
+ } ngx_http_log_loc_conf_t;
+ 
+@@ -131,7 +133,8 @@ static size_t ngx_http_log_variable_getlen(ngx_http_request_t *r,
+     uintptr_t data);
+ static u_char *ngx_http_log_variable(ngx_http_request_t *r, u_char *buf,
+     ngx_http_log_op_t *op);
+-static uintptr_t ngx_http_log_escape(u_char *dst, u_char *src, size_t size);
++static uintptr_t ngx_http_log_escape(ngx_http_log_loc_conf_t *lcf, u_char *dst,
++    u_char *src, size_t size);
+ static size_t ngx_http_log_json_variable_getlen(ngx_http_request_t *r,
+     uintptr_t data);
+ static u_char *ngx_http_log_json_variable(ngx_http_request_t *r, u_char *buf,
+@@ -177,6 +180,13 @@ static ngx_command_t  ngx_http_log_commands[] = {
+       0,
+       NULL },
+ 
++    { ngx_string("log_escape_non_ascii"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_log_loc_conf_t, escape_non_ascii),
++      NULL },
++
+       ngx_null_command
+ };
+ 
+@@ -935,6 +945,7 @@ static size_t
+ ngx_http_log_variable_getlen(ngx_http_request_t *r, uintptr_t data)
+ {
+     uintptr_t                   len;
++    ngx_http_log_loc_conf_t    *lcf;
+     ngx_http_variable_value_t  *value;
+ 
+     value = ngx_http_get_indexed_variable(r, data);
+@@ -943,7 +954,9 @@ ngx_http_log_variable_getlen(ngx_http_request_t *r, uintptr_t data)
+         return 1;
+     }
+ 
+-    len = ngx_http_log_escape(NULL, value->data, value->len);
++    lcf = ngx_http_get_module_loc_conf(r, ngx_http_log_module);
++
++    len = ngx_http_log_escape(lcf, NULL, value->data, value->len);
+ 
+     value->escape = len ? 1 : 0;
+ 
+@@ -954,6 +967,7 @@ ngx_http_log_variable_getlen(ngx_http_request_t *r, uintptr_t data)
+ static u_char *
+ ngx_http_log_variable(ngx_http_request_t *r, u_char *buf, ngx_http_log_op_t *op)
+ {
++    ngx_http_log_loc_conf_t    *lcf;
+     ngx_http_variable_value_t  *value;
+ 
+     value = ngx_http_get_indexed_variable(r, op->data);
+@@ -967,16 +981,18 @@ ngx_http_log_variable(ngx_http_request_t *r, u_char *buf, ngx_http_log_op_t *op)
+         return ngx_cpymem(buf, value->data, value->len);
+ 
+     } else {
+-        return (u_char *) ngx_http_log_escape(buf, value->data, value->len);
++        lcf = ngx_http_get_module_loc_conf(r, ngx_http_log_module);
++        return (u_char *) ngx_http_log_escape(lcf, buf, value->data, value->len);
+     }
+ }
+ 
+ 
+ static uintptr_t
+-ngx_http_log_escape(u_char *dst, u_char *src, size_t size)
++ngx_http_log_escape(ngx_http_log_loc_conf_t *lcf, u_char *dst, u_char *src,
++    size_t size)
+ {
+-    ngx_uint_t      n;
+-    static u_char   hex[] = "0123456789ABCDEF";
++    ngx_uint_t                   n;
++    static u_char                hex[] = "0123456789ABCDEF";
+ 
+     static uint32_t   escape[] = {
+         0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+@@ -996,6 +1012,12 @@ ngx_http_log_escape(u_char *dst, u_char *src, size_t size)
+         0xffffffff, /* 1111 1111 1111 1111  1111 1111 1111 1111 */
+     };
+ 
++    if (lcf->escape_non_ascii) {
++        ngx_memset(&escape[4], 0xff, sizeof(uint32_t) * 4);
++
++    } else {
++        ngx_memzero(&escape[4], sizeof(uint32_t) * 4);
++    }
+ 
+     if (dst == NULL) {
+ 
+@@ -1120,6 +1142,7 @@ ngx_http_log_create_loc_conf(ngx_conf_t *cf)
+     }
+ 
+     conf->open_file_cache = NGX_CONF_UNSET_PTR;
++    conf->escape_non_ascii = NGX_CONF_UNSET;
+ 
+     return conf;
+ }
+@@ -1135,6 +1158,8 @@ ngx_http_log_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+     ngx_http_log_fmt_t        *fmt;
+     ngx_http_log_main_conf_t  *lmcf;
+ 
++    ngx_conf_merge_value(conf->escape_non_ascii, prev->escape_non_ascii, 1);
++
+     if (conf->open_file_cache == NGX_CONF_UNSET_PTR) {
+ 
+         conf->open_file_cache = prev->open_file_cache;

--- a/patches/nginx-1.25.4-no_Werror.patch
+++ b/patches/nginx-1.25.4-no_Werror.patch
@@ -1,0 +1,36 @@
+diff -urp nginx-1.25.4/auto/cc/clang nginx-1.25.4-patched/auto/cc/clang
+--- nginx-1.25.4/auto/cc/clang	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.25.4-patched/auto/cc/clang	2014-03-13 20:54:26.241413360 -0700
+@@ -89,7 +89,7 @@ CFLAGS="$CFLAGS -Wconditional-uninitiali
+ CFLAGS="$CFLAGS -Wno-unused-parameter"
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"
+diff -urp nginx-1.25.4/auto/cc/gcc nginx-1.25.4-patched/auto/cc/gcc
+--- nginx-1.25.4/auto/cc/gcc	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.25.4-patched/auto/cc/gcc	2014-03-13 20:54:13.301355329 -0700
+@@ -168,7 +168,7 @@ esac
+ 
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"
+diff -urp nginx-1.25.4/auto/cc/icc nginx-1.25.4-patched/auto/cc/icc
+--- nginx-1.25.4/auto/cc/icc	2014-03-04 03:39:24.000000000 -0800
++++ nginx-1.25.4-patched/auto/cc/icc	2014-03-13 20:54:13.301355329 -0700
+@@ -115,7 +115,7 @@ case "$NGX_ICC_VER" in
+ esac
+ 
+ # stop on warning
+-CFLAGS="$CFLAGS -Werror"
++#CFLAGS="$CFLAGS -Werror"
+ 
+ # debug
+ CFLAGS="$CFLAGS -g"

--- a/patches/nginx-1.25.4-no_error_pages.patch
+++ b/patches/nginx-1.25.4-no_error_pages.patch
@@ -1,0 +1,91 @@
+diff -upr nginx-1.25.4/src/http/ngx_http_core_module.c nginx-1.25.4-patched/src/http/ngx_http_core_module.c
+--- nginx-1.25.4/src/http/ngx_http_core_module.c	2017-08-31 18:14:41.000000000 -0700
++++ nginx-1.25.4-patched/src/http/ngx_http_core_module.c	2017-08-31 18:21:31.638098196 -0700
+@@ -64,6 +64,8 @@ static char *ngx_http_core_directio(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
+ static char *ngx_http_core_error_page(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
++static char *ngx_http_core_no_error_pages(ngx_conf_t *cf, ngx_command_t *cmd,
++    void *conf);
+ static char *ngx_http_core_open_file_cache(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
+ static char *ngx_http_core_error_log(ngx_conf_t *cf, ngx_command_t *cmd,
+@@ -671,6 +673,14 @@ static ngx_command_t  ngx_http_core_commands[] = {
+       0,
+       NULL },
+
++    { ngx_string("no_error_pages"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
++                        |NGX_CONF_NOARGS,
++      ngx_http_core_no_error_pages,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      0,
++      NULL },
++
+     { ngx_string("post_action"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                         |NGX_CONF_TAKE1,
+@@ -3564,7 +3574,6 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
+      *     clcf->types = NULL;
+      *     clcf->default_type = { 0, NULL };
+      *     clcf->error_log = NULL;
+-     *     clcf->error_pages = NULL;
+      *     clcf->client_body_path = NULL;
+      *     clcf->regex = NULL;
+      *     clcf->exact_match = 0;
+@@ -3574,6 +3583,7 @@ ngx_http_core_create_loc_conf(ngx_conf_t *cf)
+      *     clcf->keepalive_disable = 0;
+      */
+
++    clcf->error_pages = NGX_CONF_UNSET_PTR;
+     clcf->client_max_body_size = NGX_CONF_UNSET;
+     clcf->client_body_buffer_size = NGX_CONF_UNSET_SIZE;
+     clcf->client_body_timeout = NGX_CONF_UNSET_MSEC;
+@@ -3776,9 +3786,7 @@ ngx_http_core_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+         }
+     }
+
+-    if (conf->error_pages == NULL && prev->error_pages) {
+-        conf->error_pages = prev->error_pages;
+-    }
++    ngx_conf_merge_ptr_value(conf->error_pages, prev->error_pages, NULL);
+
+     ngx_conf_merge_str_value(conf->default_type,
+                               prev->default_type, "text/plain");
+@@ -4815,6 +4823,10 @@ ngx_http_core_error_page(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+     ngx_http_compile_complex_value_t   ccv;
+
+     if (clcf->error_pages == NULL) {
++        return "conflicts with \"no_error_pages\"";
++    }
++
++    if (clcf->error_pages == NGX_CONF_UNSET_PTR) {
+         clcf->error_pages = ngx_array_create(cf->pool, 4,
+                                              sizeof(ngx_http_err_page_t));
+         if (clcf->error_pages == NULL) {
+@@ -4920,6 +4932,25 @@ ngx_http_core_error_page(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ }
+
+
++static char *
++ngx_http_core_no_error_pages(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
++{
++    ngx_http_core_loc_conf_t *clcf = conf;
++
++    if (clcf->error_pages == NULL) {
++        return "is duplicate";
++    }
++
++    if (clcf->error_pages != NGX_CONF_UNSET_PTR) {
++        return "conflicts with \"error_page\"";
++    }
++
++    clcf->error_pages = NULL;
++
++    return NGX_CONF_OK;
++}
++
++
+ static char *
+ ngx_http_core_open_file_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {

--- a/patches/nginx-1.25.4-no_pool.patch
+++ b/patches/nginx-1.25.4-no_pool.patch
@@ -1,0 +1,587 @@
+diff --minimal '--exclude=*.swp' '--exclude=*~' -up nginx-1.25.4/src/core/nginx.h nginx-1.25.4-patched/src/core/nginx.h
+--- nginx-1.25.4/src/core/nginx.h	2016-04-19 09:02:38.000000000 -0700
++++ nginx-1.25.4-patched/src/core/nginx.h	2016-04-21 16:25:07.452944624 -0700
+@@ -10,7 +10,7 @@
+ 
+ 
+ #define nginx_version      1025003
+ #define NGINX_VERSION      "1.25.4"
+-#define NGINX_VER          "openresty/" NGINX_VERSION ".unknown"
++#define NGINX_VER          "openresty/" NGINX_VERSION ".unknown (no pool)"
+ 
+ #ifdef NGX_BUILD
+diff --minimal '--exclude=*.swp' '--exclude=*~' -up nginx-1.25.4/src/core/ngx_array.c nginx-1.25.4-patched/src/core/ngx_array.c
+--- nginx-1.25.4/src/core/ngx_array.c	2016-04-19 09:02:38.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_array.c	2016-04-21 16:25:07.453947190 -0700
+@@ -30,26 +30,30 @@ ngx_array_create(ngx_pool_t *p, ngx_uint
+ void
+ ngx_array_destroy(ngx_array_t *a)
+ {
+-    ngx_pool_t  *p;
++    ngx_pool_t          *p;
++    ngx_array_link_t    *link;
+ 
+     p = a->pool;
+ 
+-    if ((u_char *) a->elts + a->size * a->nalloc == p->d.last) {
+-        p->d.last -= a->size * a->nalloc;
++    if (a->elts) {
++        ngx_pfree(p, a->elts);
+     }
+ 
+-    if ((u_char *) a + sizeof(ngx_array_t) == p->d.last) {
+-        p->d.last = (u_char *) a;
++    for (link = a->old_elts; link; link = link->next) {
++        ngx_pfree(p, link->elts);
+     }
++
++    ngx_pfree(p, a);
+ }
+ 
+ 
+ void *
+ ngx_array_push(ngx_array_t *a)
+ {
+-    void        *elt, *new;
+-    size_t       size;
+-    ngx_pool_t  *p;
++    void                *elt, *new;
++    size_t               size;
++    ngx_pool_t          *p;
++    ngx_array_link_t    *link;
+ 
+     if (a->nelts == a->nalloc) {
+ 
+@@ -59,29 +63,27 @@ ngx_array_push(ngx_array_t *a)
+ 
+         p = a->pool;
+ 
+-        if ((u_char *) a->elts + size == p->d.last
+-            && p->d.last + a->size <= p->d.end)
+-        {
+-            /*
+-             * the array allocation is the last in the pool
+-             * and there is space for new allocation
+-             */
+-
+-            p->d.last += a->size;
+-            a->nalloc++;
++        /* allocate a new array */
+ 
+-        } else {
+-            /* allocate a new array */
++        new = ngx_palloc(p, 2 * size);
++        if (new == NULL) {
++            return NULL;
++        }
+ 
+-            new = ngx_palloc(p, 2 * size);
+-            if (new == NULL) {
+-                return NULL;
+-            }
++        ngx_memcpy(new, a->elts, size);
+ 
+-            ngx_memcpy(new, a->elts, size);
+-            a->elts = new;
+-            a->nalloc *= 2;
++        link = ngx_palloc(p, sizeof(ngx_array_link_t));
++        if (link == NULL) {
++            ngx_pfree(p, new);
++            return NULL;
+         }
++
++        link->next = a->old_elts;
++        link->elts = a->elts;
++        a->old_elts = link;
++
++        a->elts = new;
++        a->nalloc *= 2;
+     }
+ 
+     elt = (u_char *) a->elts + a->size * a->nelts;
+@@ -95,11 +97,10 @@ void *
+ ngx_array_push_n(ngx_array_t *a, ngx_uint_t n)
+ {
+     void        *elt, *new;
+-    size_t       size;
+     ngx_uint_t   nalloc;
+     ngx_pool_t  *p;
+ 
+-    size = n * a->size;
++    ngx_array_link_t    *link;
+ 
+     if (a->nelts + n > a->nalloc) {
+ 
+@@ -107,31 +108,27 @@ ngx_array_push_n(ngx_array_t *a, ngx_uin
+ 
+         p = a->pool;
+ 
+-        if ((u_char *) a->elts + a->size * a->nalloc == p->d.last
+-            && p->d.last + size <= p->d.end)
+-        {
+-            /*
+-             * the array allocation is the last in the pool
+-             * and there is space for new allocation
+-             */
++        nalloc = 2 * ((n >= a->nalloc) ? n : a->nalloc);
+ 
+-            p->d.last += size;
+-            a->nalloc += n;
++        new = ngx_palloc(p, nalloc * a->size);
++        if (new == NULL) {
++            return NULL;
++        }
+ 
+-        } else {
+-            /* allocate a new array */
++        ngx_memcpy(new, a->elts, a->nelts * a->size);
+ 
+-            nalloc = 2 * ((n >= a->nalloc) ? n : a->nalloc);
++        link = ngx_palloc(p, sizeof(ngx_array_link_t));
++        if (link == NULL) {
++            ngx_pfree(p, new);
++            return NULL;
++        }
+ 
+-            new = ngx_palloc(p, nalloc * a->size);
+-            if (new == NULL) {
+-                return NULL;
+-            }
++        link->next = a->old_elts;
++        link->elts = a->elts;
++        a->old_elts = link;
+ 
+-            ngx_memcpy(new, a->elts, a->nelts * a->size);
+-            a->elts = new;
+-            a->nalloc = nalloc;
+-        }
++        a->elts = new;
++        a->nalloc = nalloc;
+     }
+ 
+     elt = (u_char *) a->elts + a->size * a->nelts;
+diff --minimal '--exclude=*.swp' '--exclude=*~' -up nginx-1.25.4/src/core/ngx_array.h nginx-1.25.4-patched/src/core/ngx_array.h
+--- nginx-1.25.4/src/core/ngx_array.h	2016-04-19 09:02:38.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_array.h	2016-04-21 16:25:07.453947190 -0700
+@@ -13,12 +13,23 @@
+ #include <ngx_core.h>
+ 
+ 
++typedef struct ngx_array_link_s ngx_array_link_t;
++
++
++struct ngx_array_link_s {
++    void                    *elts;
++    ngx_array_link_t        *next;
++};
++
++
+ typedef struct {
+     void        *elts;
+     ngx_uint_t   nelts;
+     size_t       size;
+     ngx_uint_t   nalloc;
+     ngx_pool_t  *pool;
++
++    ngx_array_link_t *old_elts;
+ } ngx_array_t;
+ 
+ 
+@@ -40,6 +51,7 @@ ngx_array_init(ngx_array_t *array, ngx_p
+     array->size = size;
+     array->nalloc = n;
+     array->pool = pool;
++    array->old_elts = NULL;
+ 
+     array->elts = ngx_palloc(pool, n * size);
+     if (array->elts == NULL) {
+diff --minimal '--exclude=*.swp' '--exclude=*~' -up nginx-1.25.4/src/core/ngx_palloc.c nginx-1.25.4-patched/src/core/ngx_palloc.c
+--- nginx-1.25.4/src/core/ngx_palloc.c	2016-04-19 09:02:38.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_palloc.c	2016-04-21 16:25:45.912282685 -0700
+@@ -9,34 +9,26 @@
+ #include <ngx_core.h>
+ 
+ 
+-static ngx_inline void *ngx_palloc_small(ngx_pool_t *pool, size_t size,
+-    ngx_uint_t align);
+-static void *ngx_palloc_block(ngx_pool_t *pool, size_t size);
+-static void *ngx_palloc_large(ngx_pool_t *pool, size_t size);
++static void * ngx_malloc(ngx_pool_t *pool, size_t size);
+ 
+ 
+ ngx_pool_t *
+ ngx_create_pool(size_t size, ngx_log_t *log)
+ {
+-    ngx_pool_t  *p;
++    ngx_pool_t        *p;
+ 
+-    p = ngx_memalign(NGX_POOL_ALIGNMENT, size, log);
++    size = sizeof(ngx_pool_t);
++    p = ngx_alloc(size, log);
+     if (p == NULL) {
+         return NULL;
+     }
+ 
+-    p->d.last = (u_char *) p + sizeof(ngx_pool_t);
+-    p->d.end = (u_char *) p + size;
+-    p->d.next = NULL;
+-    p->d.failed = 0;
++    ngx_memzero(p, size);
+ 
+     size = size - sizeof(ngx_pool_t);
+     p->max = (size < NGX_MAX_ALLOC_FROM_POOL) ? size : NGX_MAX_ALLOC_FROM_POOL;
+ 
+     p->current = p;
+-    p->chain = NULL;
+-    p->large = NULL;
+-    p->cleanup = NULL;
+     p->log = log;
+ 
+     return p;
+@@ -46,8 +38,7 @@ ngx_create_pool(size_t size, ngx_log_t *
+ void
+ ngx_destroy_pool(ngx_pool_t *pool)
+ {
+-    ngx_pool_t          *p, *n;
+-    ngx_pool_large_t    *l;
++    ngx_pool_data_t     *d, *n;
+     ngx_pool_cleanup_t  *c;
+ 
+     for (c = pool->cleanup; c; c = c->next) {
+@@ -58,6 +49,11 @@ ngx_destroy_pool(ngx_pool_t *pool)
+         }
+     }
+ 
++    if (pool->d == NULL) {
++        ngx_free(pool);
++        return;
++    }
++
+ #if (NGX_DEBUG)
+ 
+     /*
+@@ -65,13 +61,9 @@ ngx_destroy_pool(ngx_pool_t *pool)
+      * so we cannot use this log while free()ing the pool
+      */
+ 
+-    for (l = pool->large; l; l = l->next) {
+-        ngx_log_debug1(NGX_LOG_DEBUG_ALLOC, pool->log, 0, "free: %p", l->alloc);
+-    }
+-
+-    for (p = pool, n = pool->d.next; /* void */; p = n, n = n->d.next) {
++    for (d = pool->d, n = d->next; ; d = n, n = n->next) {
+         ngx_log_debug2(NGX_LOG_DEBUG_ALLOC, pool->log, 0,
+-                       "free: %p, unused: %uz", p, p->d.end - p->d.last);
++                       "free: %p, unused: %d", d, 0);
+ 
+         if (n == NULL) {
+             break;
+@@ -80,171 +72,82 @@ ngx_destroy_pool(ngx_pool_t *pool)
+ 
+ #endif
+ 
+-    for (l = pool->large; l; l = l->next) {
+-        if (l->alloc) {
+-            ngx_free(l->alloc);
+-        }
+-    }
+-
+-    for (p = pool, n = pool->d.next; /* void */; p = n, n = n->d.next) {
+-        ngx_free(p);
++    for (d = pool->d, n = d->next; ; d = n, n = n->next) {
++        ngx_free(d->alloc);
++        ngx_free(d);
+ 
+         if (n == NULL) {
+             break;
+         }
+     }
++
++    pool->d = NULL;
++    ngx_free(pool);
+ }
+ 
+ 
+ void
+ ngx_reset_pool(ngx_pool_t *pool)
+ {
+-    ngx_pool_t        *p;
+-    ngx_pool_large_t  *l;
++    ngx_pool_data_t     *d, *n;
++    ngx_pool_data_t     *saved = NULL;
+ 
+-    for (l = pool->large; l; l = l->next) {
+-        if (l->alloc) {
+-            ngx_free(l->alloc);
++    if (pool->d) {
++        for (d = pool->d, n = d->next; ; d = n, n = n->next) {
++            if (d->alloc == pool->log) {
++                saved = d;
++                continue;
++            }
++
++            ngx_free(d->alloc);
++            ngx_free(d);
++
++            if (n == NULL) {
++                break;
++            }
+         }
+-    }
+ 
+-    for (p = pool; p; p = p->d.next) {
+-        p->d.last = (u_char *) p + sizeof(ngx_pool_t);
+-        p->d.failed = 0;
++        pool->d = saved;
++        pool->current = pool;
++        pool->chain = NULL;
+     }
+-
+-    pool->current = pool;
+-    pool->chain = NULL;
+-    pool->large = NULL;
+ }
+ 
+ 
+ void *
+ ngx_palloc(ngx_pool_t *pool, size_t size)
+ {
+-#if !(NGX_DEBUG_PALLOC)
+-    if (size <= pool->max) {
+-        return ngx_palloc_small(pool, size, 1);
+-    }
+-#endif
+-
+-    return ngx_palloc_large(pool, size);
++    return ngx_malloc(pool, size);
+ }
+ 
+ 
+ void *
+ ngx_pnalloc(ngx_pool_t *pool, size_t size)
+ {
+-#if !(NGX_DEBUG_PALLOC)
+-    if (size <= pool->max) {
+-        return ngx_palloc_small(pool, size, 0);
+-    }
+-#endif
+-
+-    return ngx_palloc_large(pool, size);
+-}
+-
+-
+-static ngx_inline void *
+-ngx_palloc_small(ngx_pool_t *pool, size_t size, ngx_uint_t align)
+-{
+-    u_char      *m;
+-    ngx_pool_t  *p;
+-
+-    p = pool->current;
+-
+-    do {
+-        m = p->d.last;
+-
+-        if (align) {
+-            m = ngx_align_ptr(m, NGX_ALIGNMENT);
+-        }
+-
+-        if ((size_t) (p->d.end - m) >= size) {
+-            p->d.last = m + size;
+-
+-            return m;
+-        }
+-
+-        p = p->d.next;
+-
+-    } while (p);
+-
+-    return ngx_palloc_block(pool, size);
+-}
+-
+-
+-static void *
+-ngx_palloc_block(ngx_pool_t *pool, size_t size)
+-{
+-    u_char      *m;
+-    size_t       psize;
+-    ngx_pool_t  *p, *new;
+-
+-    psize = (size_t) (pool->d.end - (u_char *) pool);
+-
+-    m = ngx_memalign(NGX_POOL_ALIGNMENT, psize, pool->log);
+-    if (m == NULL) {
+-        return NULL;
+-    }
+-
+-    new = (ngx_pool_t *) m;
+-
+-    new->d.end = m + psize;
+-    new->d.next = NULL;
+-    new->d.failed = 0;
+-
+-    m += sizeof(ngx_pool_data_t);
+-    m = ngx_align_ptr(m, NGX_ALIGNMENT);
+-    new->d.last = m + size;
+-
+-    for (p = pool->current; p->d.next; p = p->d.next) {
+-        if (p->d.failed++ > 4) {
+-            pool->current = p->d.next;
+-        }
+-    }
+-
+-    p->d.next = new;
+-
+-    return m;
++    return ngx_malloc(pool, size);
+ }
+ 
+ 
+ static void *
+-ngx_palloc_large(ngx_pool_t *pool, size_t size)
++ngx_malloc(ngx_pool_t *pool, size_t size)
+ {
+-    void              *p;
+-    ngx_uint_t         n;
+-    ngx_pool_large_t  *large;
++    void                *p;
++    ngx_pool_data_t     *d;
+ 
+     p = ngx_alloc(size, pool->log);
+     if (p == NULL) {
+         return NULL;
+     }
+ 
+-    n = 0;
+-
+-    for (large = pool->large; large; large = large->next) {
+-        if (large->alloc == NULL) {
+-            large->alloc = p;
+-            return p;
+-        }
+-
+-        if (n++ > 3) {
+-            break;
+-        }
+-    }
+-
+-    large = ngx_palloc_small(pool, sizeof(ngx_pool_large_t), 1);
+-    if (large == NULL) {
++    d = ngx_alloc(sizeof(ngx_pool_data_t), pool->log);
++    if (d == NULL){
+         ngx_free(p);
+         return NULL;
+     }
+ 
+-    large->alloc = p;
+-    large->next = pool->large;
+-    pool->large = large;
+-
++    d->alloc = p;
++    d->next = pool->d;
++    pool->d = d;
+     return p;
+ }
+ 
+@@ -253,38 +156,48 @@ void *
+ ngx_pmemalign(ngx_pool_t *pool, size_t size, size_t alignment)
+ {
+     void              *p;
+-    ngx_pool_large_t  *large;
++    ngx_pool_data_t   *d;
+ 
+     p = ngx_memalign(alignment, size, pool->log);
+     if (p == NULL) {
+         return NULL;
+     }
+ 
+-    large = ngx_palloc_small(pool, sizeof(ngx_pool_large_t), 1);
+-    if (large == NULL) {
++    d = ngx_alloc(sizeof(ngx_pool_data_t), pool->log);
++    if (d == NULL){
+         ngx_free(p);
+         return NULL;
+     }
+ 
+-    large->alloc = p;
+-    large->next = pool->large;
+-    pool->large = large;
+-
++    d->alloc = p;
++    d->next = pool->d;
++    pool->d = d;
+     return p;
+ }
+ 
+ 
+ ngx_int_t
+-ngx_pfree(ngx_pool_t *pool, void *p)
++ngx_pfree(ngx_pool_t *pool, void *data)
+ {
+-    ngx_pool_large_t  *l;
++    ngx_pool_data_t     *p, *d;
+ 
+-    for (l = pool->large; l; l = l->next) {
+-        if (p == l->alloc) {
+-            ngx_log_debug1(NGX_LOG_DEBUG_ALLOC, pool->log, 0,
+-                           "free: %p", l->alloc);
+-            ngx_free(l->alloc);
+-            l->alloc = NULL;
++    p = NULL;
++    for (d = pool->d; d; p = d, d = d->next) {
++        if (data == d->alloc) {
++
++            ngx_log_debug1(NGX_LOG_DEBUG_ALLOC, pool->log, 0, "free: %p", d->alloc);
++
++            ngx_free(d->alloc);
++            d->alloc = NULL;
++
++            if (p) {
++                p->next = d->next;
++
++            } else {
++                pool->d = d->next;
++            }
++
++            ngx_free(d);
+ 
+             return NGX_OK;
+         }
+diff --minimal '--exclude=*.swp' '--exclude=*~' -up nginx-1.25.4/src/core/ngx_palloc.h nginx-1.25.4-patched/src/core/ngx_palloc.h
+--- nginx-1.25.4/src/core/ngx_palloc.h	2016-04-19 09:02:38.000000000 -0700
++++ nginx-1.25.4-patched/src/core/ngx_palloc.h	2016-04-21 16:25:07.454949755 -0700
+@@ -38,28 +38,21 @@ struct ngx_pool_cleanup_s {
+ };
+ 
+ 
+-typedef struct ngx_pool_large_s  ngx_pool_large_t;
+-
+-struct ngx_pool_large_s {
+-    ngx_pool_large_t     *next;
+-    void                 *alloc;
+-};
++typedef struct ngx_pool_data_s   ngx_pool_large_t;
++typedef struct ngx_pool_data_s   ngx_pool_data_t;
+ 
+ 
+-typedef struct {
+-    u_char               *last;
+-    u_char               *end;
+-    ngx_pool_t           *next;
+-    ngx_uint_t            failed;
+-} ngx_pool_data_t;
++struct ngx_pool_data_s {
++    ngx_pool_data_t        *next;
++    void                   *alloc;
++};
+ 
+ 
+ struct ngx_pool_s {
+-    ngx_pool_data_t       d;
++    ngx_pool_data_t      *d;
+     size_t                max;
+     ngx_pool_t           *current;
+     ngx_chain_t          *chain;
+-    ngx_pool_large_t     *large;
+     ngx_pool_cleanup_t   *cleanup;
+     ngx_log_t            *log;
+ };

--- a/patches/nginx-1.25.4-pcre_conf_opt.patch
+++ b/patches/nginx-1.25.4-pcre_conf_opt.patch
@@ -1,0 +1,26 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1386694955 28800
+# Node ID 9ba6b149669f1f02eeb4cdc0ebd364a949b5c469
+# Parent  30e806b8636af5fd3f03ec17df24801f390f7511
+Configure: added new option --with-pcre-conf-opt=OPTIONS.
+
+diff -r 30e806b8636a -r 9ba6b149669f auto/options
+--- a/auto/options	Mon Dec 09 10:16:44 2013 +0400
++++ b/auto/options	Tue Dec 10 09:02:35 2013 -0800
+@@ -286,6 +286,7 @@
+         --with-pcre)                     USE_PCRE=YES               ;;
+         --with-pcre=*)                   PCRE="$value"              ;;
+         --with-pcre-opt=*)               PCRE_OPT="$value"          ;;
++        --with-pcre-conf-opt=*)          PCRE_CONF_OPT="$value"     ;;
+         --with-pcre-jit)                 PCRE_JIT=YES               ;;
+ 
+         --with-openssl=*)                OPENSSL="$value"           ;;
+@@ -441,6 +442,7 @@
+   --with-pcre                        force PCRE library usage
+   --with-pcre=DIR                    set path to PCRE library sources
+   --with-pcre-opt=OPTIONS            set additional build options for PCRE
++  --with-pcre-conf-opt=OPTIONS       set additional configure options for PCRE
+   --with-pcre-jit                    build PCRE with JIT compilation support
+ 
+   --with-md5=DIR                     set path to md5 library sources

--- a/patches/nginx-1.25.4-privileged_agent_process.patch
+++ b/patches/nginx-1.25.4-privileged_agent_process.patch
@@ -1,0 +1,203 @@
+diff --git a/src/core/nginx.c b/src/core/nginx.c
+index 60f8fe7..4bd244b 100644
+--- a/src/core/nginx.c
++++ b/src/core/nginx.c
+@@ -981,6 +981,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
+ 
+     ccf->daemon = NGX_CONF_UNSET;
+     ccf->master = NGX_CONF_UNSET;
++    ccf->privileged_agent = NGX_CONF_UNSET;
+     ccf->timer_resolution = NGX_CONF_UNSET_MSEC;
+ 
+     ccf->worker_processes = NGX_CONF_UNSET;
+@@ -1009,6 +1010,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
+ 
+     ngx_conf_init_value(ccf->daemon, 1);
+     ngx_conf_init_value(ccf->master, 1);
++    ngx_conf_init_value(ccf->privileged_agent, 0);
+     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
+ 
+     ngx_conf_init_value(ccf->worker_processes, 1);
+diff --git a/src/core/ngx_cycle.h b/src/core/ngx_cycle.h
+index c51b7ff..3261f90 100644
+--- a/src/core/ngx_cycle.h
++++ b/src/core/ngx_cycle.h
+@@ -22,6 +22,9 @@
+ #define NGX_DEBUG_POINTS_ABORT  2
+ 
+ 
++#define HAVE_PRIVILEGED_PROCESS_PATCH   1
++
++
+ typedef struct ngx_shm_zone_s  ngx_shm_zone_t;
+ 
+ typedef ngx_int_t (*ngx_shm_zone_init_pt) (ngx_shm_zone_t *zone, void *data);
+@@ -81,6 +84,7 @@ struct ngx_cycle_s {
+ typedef struct {
+     ngx_flag_t                daemon;
+     ngx_flag_t                master;
++    ngx_flag_t                privileged_agent;
+ 
+     ngx_msec_t                timer_resolution;
+ 
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index 7cee1c5..c4f70d6 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -15,6 +15,8 @@ static void ngx_start_worker_processes(ngx_cycle_t *cycle, ngx_int_t n,
+     ngx_int_t type);
+ static void ngx_start_cache_manager_processes(ngx_cycle_t *cycle,
+     ngx_uint_t respawn);
++static void ngx_start_privileged_agent_processes(ngx_cycle_t *cycle,
++    ngx_uint_t respawn);
+ static void ngx_pass_open_channel(ngx_cycle_t *cycle);
+ static void ngx_signal_worker_processes(ngx_cycle_t *cycle, int signo);
+ static ngx_uint_t ngx_reap_children(ngx_cycle_t *cycle);
+@@ -24,6 +26,7 @@ static void ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker);
+ static void ngx_worker_process_exit(ngx_cycle_t *cycle);
+ static void ngx_channel_handler(ngx_event_t *ev);
+ static void ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data);
++static void ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data);
+ static void ngx_cache_manager_process_handler(ngx_event_t *ev);
+ static void ngx_cache_loader_process_handler(ngx_event_t *ev);
+ 
+@@ -51,6 +54,8 @@ sig_atomic_t  ngx_noaccept;
+ ngx_uint_t    ngx_noaccepting;
+ ngx_uint_t    ngx_restart;
+ 
++ngx_uint_t    ngx_is_privileged_agent;
++
+ 
+ static u_char  master_process[] = "master process";
+ 
+@@ -130,6 +135,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+     ngx_start_worker_processes(cycle, ccf->worker_processes,
+                                NGX_PROCESS_RESPAWN);
+     ngx_start_cache_manager_processes(cycle, 0);
++    ngx_start_privileged_agent_processes(cycle, 0);
+ 
+     ngx_new_binary = 0;
+     delay = 0;
+@@ -215,6 +221,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+                 ngx_start_worker_processes(cycle, ccf->worker_processes,
+                                            NGX_PROCESS_RESPAWN);
+                 ngx_start_cache_manager_processes(cycle, 0);
++                ngx_start_privileged_agent_processes(cycle, 0);
+                 ngx_noaccepting = 0;
+ 
+                 continue;
+@@ -234,6 +241,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+             ngx_start_worker_processes(cycle, ccf->worker_processes,
+                                        NGX_PROCESS_JUST_RESPAWN);
+             ngx_start_cache_manager_processes(cycle, 1);
++            ngx_start_privileged_agent_processes(cycle, 1);
+ 
+             /* allow new processes to start */
+             ngx_msleep(100);
+@@ -248,6 +256,7 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+             ngx_start_worker_processes(cycle, ccf->worker_processes,
+                                        NGX_PROCESS_RESPAWN);
+             ngx_start_cache_manager_processes(cycle, 0);
++            ngx_start_privileged_agent_processes(cycle, 0);
+             live = 1;
+         }
+ 
+@@ -393,6 +431,26 @@ ngx_start_cache_manager_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
+ 
+ 
+ static void
++ngx_start_privileged_agent_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
++{
++    ngx_core_conf_t       *ccf;
++
++    ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
++                                           ngx_core_module);
++
++    if (!ccf->privileged_agent) {
++        return;
++    }
++
++    ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
++                      "privileged agent process", "privileged agent process",
++                      respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);
++
++    ngx_pass_open_channel(cycle);
++}
++
++
++static void
+ ngx_pass_open_channel(ngx_cycle_t *cycle)
+ {
+     ngx_int_t  i;
+@@ -794,7 +860,10 @@ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
+         }
+     }
+ 
+-    if (geteuid() == 0) {
++    /*
++     * privileged agent process has the same permission as master process
++     */
++    if (!ngx_is_privileged_agent && geteuid() == 0) {
+         if (setgid(ccf->group) == -1) {
+             ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno,
+                           "setgid(%d) failed", ccf->group);
+@@ -1149,6 +1216,47 @@ ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data)
+ 
+ 
+ static void
++ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
++{
++    char   *name = data;
++
++    /*
++     * Set correct process type since closing listening Unix domain socket
++     * in a master process also removes the Unix domain socket file.
++     */
++    ngx_process = NGX_PROCESS_HELPER;
++    ngx_is_privileged_agent = 1;
++
++    ngx_close_listening_sockets(cycle);
++
++    /* Set a moderate number of connections for a helper process. */
++    cycle->connection_n = 512;
++
++    ngx_worker_process_init(cycle, -1);
++
++    ngx_use_accept_mutex = 0;
++
++    ngx_setproctitle(name);
++
++    for ( ;; ) {
++
++        if (ngx_terminate || ngx_quit) {
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
++            ngx_worker_process_exit(cycle);
++        }
++
++        if (ngx_reopen) {
++            ngx_reopen = 0;
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");
++            ngx_reopen_files(cycle, -1);
++        }
++
++        ngx_process_events_and_timers(cycle);
++    }
++}
++
++
++static void
+ ngx_cache_manager_process_handler(ngx_event_t *ev)
+ {
+     time_t        next, n;
+diff --git a/src/os/unix/ngx_process_cycle.h b/src/os/unix/ngx_process_cycle.h
+index 69495d5..5149396 100644
+--- a/src/os/unix/ngx_process_cycle.h
++++ b/src/os/unix/ngx_process_cycle.h
+@@ -45,6 +45,7 @@ extern ngx_pid_t       ngx_new_binary;
+ extern ngx_uint_t      ngx_inherited;
+ extern ngx_uint_t      ngx_daemonized;
+ extern ngx_uint_t      ngx_exiting;
++extern ngx_uint_t      ngx_is_privileged_agent;
+ 
+ extern sig_atomic_t    ngx_reap;
+ extern sig_atomic_t    ngx_sigio;

--- a/patches/nginx-1.25.4-privileged_agent_process_connections.patch
+++ b/patches/nginx-1.25.4-privileged_agent_process_connections.patch
@@ -1,0 +1,73 @@
+diff --git a/src/core/nginx.c b/src/core/nginx.c
+index 269ff84..48329bd 100644
+--- a/src/core/nginx.c
++++ b/src/core/nginx.c
+@@ -1062,6 +1062,7 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
+     ccf->daemon = NGX_CONF_UNSET;
+     ccf->master = NGX_CONF_UNSET;
+     ccf->privileged_agent = NGX_CONF_UNSET;
++    ccf->privileged_agent_connections = NGX_CONF_UNSET_UINT;
+     ccf->timer_resolution = NGX_CONF_UNSET_MSEC;
+     ccf->shutdown_timeout = NGX_CONF_UNSET_MSEC;
+ 
+@@ -1092,6 +1093,7 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
+     ngx_conf_init_value(ccf->daemon, 1);
+     ngx_conf_init_value(ccf->master, 1);
+     ngx_conf_init_value(ccf->privileged_agent, 0);
++    ngx_conf_init_uint_value(ccf->privileged_agent_connections, 512);
+     ngx_conf_init_msec_value(ccf->timer_resolution, 0);
+     ngx_conf_init_msec_value(ccf->shutdown_timeout, 0);
+ 
+diff --git a/src/core/ngx_cycle.h b/src/core/ngx_cycle.h
+index 6a9583e..4469390 100644
+--- a/src/core/ngx_cycle.h
++++ b/src/core/ngx_cycle.h
+@@ -93,6 +93,7 @@ typedef struct {
+     ngx_flag_t                daemon;
+     ngx_flag_t                master;
+     ngx_flag_t                privileged_agent;
++    ngx_uint_t                privileged_agent_connections;
+ 
+     ngx_msec_t                timer_resolution;
+     ngx_msec_t                shutdown_timeout;
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -1179,6 +1179,7 @@ static void
+ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+ {
+     char   *name = data;
++    ngx_core_conf_t *ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx, ngx_core_module);
+ 
+     /*
+      * Set correct process type since closing listening Unix domain socket
+@@ -1190,7 +1191,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+     ngx_close_listening_sockets(cycle);
+ 
+     /* Set a moderate number of connections for a helper process. */
+-    cycle->connection_n = 512;
++    cycle->connection_n = ccf->privileged_agent_connections;
+ 
+     ngx_worker_process_init(cycle, -1);
+ 
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index df25f9d..bd259c1 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -442,6 +442,15 @@
+         return;
+     }
+ 
++    /* 0 is an illegal value and may result in a core dump later */
++    if (ccf->privileged_agent_connections == 0) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
++                      "%ui worker_connection is not enough, "
++                      "privileged agent process cannot be spawned",
++                      ccf->privileged_agent_connections);
++        return;
++    }
++
+     ngx_spawn_process(cycle, ngx_privileged_agent_process_cycle,
+                       "privileged agent process", "privileged agent process",
+                       respawn ? NGX_PROCESS_JUST_RESPAWN : NGX_PROCESS_RESPAWN);

--- a/patches/nginx-1.25.4-privileged_agent_process_thread_pool.patch
+++ b/patches/nginx-1.25.4-privileged_agent_process_thread_pool.patch
@@ -1,0 +1,12 @@
+--- a/src/core/ngx_thread_pool.c
++++ b/src/core/ngx_thread_pool.c
+@@ -587,7 +587,8 @@
+     ngx_thread_pool_conf_t   *tcf;
+ 
+     if (ngx_process != NGX_PROCESS_WORKER
+-        && ngx_process != NGX_PROCESS_SINGLE)
++        && ngx_process != NGX_PROCESS_SINGLE
++        && !ngx_is_privileged_agent)
+     {
+         return NGX_OK;
+     }

--- a/patches/nginx-1.25.4-proxy_host_port_vars.patch
+++ b/patches/nginx-1.25.4-proxy_host_port_vars.patch
@@ -1,0 +1,19 @@
+--- nginx-1.25.4/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
++++ nginx-1.25.4-patched/src/http/modules/ngx_http_proxy_module.c	2017-07-16 14:02:51.000000000 +0800
+@@ -793,13 +793,13 @@ static ngx_keyval_t  ngx_http_proxy_cach
+ static ngx_http_variable_t  ngx_http_proxy_vars[] = {
+ 
+     { ngx_string("proxy_host"), NULL, ngx_http_proxy_host_variable, 0,
+-      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
++      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
+     { ngx_string("proxy_port"), NULL, ngx_http_proxy_port_variable, 0,
+-      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE|NGX_HTTP_VAR_NOHASH, 0 },
++      NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
+     { ngx_string("proxy_add_x_forwarded_for"), NULL,
+-      ngx_http_proxy_add_x_forwarded_for_variable, 0, NGX_HTTP_VAR_NOHASH, 0 },
++      ngx_http_proxy_add_x_forwarded_for_variable, 0, 0, 0 },
+ 
+ #if 0
+     { ngx_string("proxy_add_via"), NULL, NULL, 0, NGX_HTTP_VAR_NOHASH, 0 },

--- a/patches/nginx-1.25.4-resolver_conf_parsing.patch
+++ b/patches/nginx-1.25.4-resolver_conf_parsing.patch
@@ -1,0 +1,263 @@
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index cd55520c..dade1846 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -9,12 +9,26 @@
+ #include <ngx_core.h>
+ #include <ngx_event.h>
+ 
++#if !(NGX_WIN32)
++#include <resolv.h>
++#endif
++
+ 
+ #define NGX_RESOLVER_UDP_SIZE   4096
+ 
+ #define NGX_RESOLVER_TCP_RSIZE  (2 + 65535)
+ #define NGX_RESOLVER_TCP_WSIZE  8192
+ 
++#if !(NGX_WIN32)
++/*
++ * note that 2KB should be more than enough for majority of the
++ * resolv.conf files out there. it also acts as a safety guard to prevent
++ * abuse.
++ */
++#define NGX_RESOLVER_FILE_BUF_SIZE  2048
++#define NGX_RESOLVER_FILE_NAME      "/etc/resolv.conf"
++#endif
++
+ 
+ typedef struct {
+     u_char  ident_hi;
+@@ -131,6 +145,191 @@ static ngx_resolver_node_t *ngx_resolver_lookup_addr6(ngx_resolver_t *r,
+ #endif
+ 
+ 
++#if !(NGX_WIN32)
++static ngx_int_t
++ngx_resolver_read_resolv_conf(ngx_conf_t *cf, ngx_resolver_t *r, u_char *path,
++    size_t path_len)
++{
++    ngx_url_t                        u;
++    ngx_resolver_connection_t       *rec;
++    ngx_fd_t                         fd;
++    ngx_file_t                       file;
++    u_char                           buf[NGX_RESOLVER_FILE_BUF_SIZE];
++    u_char                           ipv6_buf[NGX_INET6_ADDRSTRLEN];
++    ngx_uint_t                       address = 0, j, total = 0;
++    ssize_t                          n, i;
++    enum {
++        sw_nameserver,
++        sw_spaces,
++        sw_address,
++        sw_skip
++    } state;
++
++    file.name.data = path;
++    file.name.len = path_len;
++
++    if (ngx_conf_full_name(cf->cycle, &file.name, 1) != NGX_OK) {
++        return NGX_ERROR;
++    }
++
++    fd = ngx_open_file(file.name.data, NGX_FILE_RDONLY,
++                       NGX_FILE_OPEN, 0);
++
++    if (fd == NGX_INVALID_FILE) {
++        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
++                           ngx_open_file_n " \"%s\" failed", file.name.data);
++
++        return NGX_ERROR;
++    }
++
++    ngx_memzero(&file, sizeof(ngx_file_t));
++
++    file.fd = fd;
++    file.log = cf->log;
++
++    state = sw_nameserver;
++
++    n = ngx_read_file(&file, buf, NGX_RESOLVER_FILE_BUF_SIZE, 0);
++
++    if (n == NGX_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_read_file_n " \"%s\" failed", file.name.data);
++    }
++
++    if (ngx_close_file(file.fd) == NGX_FILE_ERROR) {
++        ngx_conf_log_error(NGX_LOG_ALERT, cf, ngx_errno,
++                           ngx_close_file_n " \"%s\" failed", file.name.data);
++    }
++
++    if (n == NGX_ERROR) {
++        return NGX_ERROR;
++    }
++
++    if (n == 0) {
++        return NGX_OK;
++    }
++
++    for (i = 0; i < n && total < MAXNS; /* void */) {
++        if (buf[i] == '#' || buf[i] == ';') {
++            state = sw_skip;
++        }
++
++        switch (state) {
++
++        case sw_nameserver:
++
++            if ((size_t) n - i >= sizeof("nameserver") - 1
++                && ngx_memcmp(buf + i, "nameserver",
++                              sizeof("nameserver") - 1) == 0)
++            {
++                state = sw_spaces;
++                i += sizeof("nameserver") - 1;
++
++                continue;
++            }
++
++            break;
++
++        case sw_spaces:
++            if (buf[i] != '\t' && buf[i] != ' ') {
++                address = i;
++                state = sw_address;
++            }
++
++            break;
++
++        case sw_address:
++
++            if (buf[i] == CR || buf[i] == LF || i == n - 1) {
++                ngx_memzero(&u, sizeof(ngx_url_t));
++
++                u.url.data = buf + address;
++
++                if (i == n - 1 && buf[i] != CR && buf[i] != LF) {
++                    u.url.len = n - address;
++
++                } else {
++                    u.url.len = i - address;
++                }
++
++                u.default_port = 53;
++
++                /* IPv6? */
++                if (ngx_strlchr(u.url.data, u.url.data + u.url.len,
++                                ':') != NULL)
++                {
++                    if (u.url.len + 2 > sizeof(ipv6_buf)) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "IPv6 resolver address is too long:"
++                                           " \"%V\"", &u.url);
++
++                        return NGX_ERROR;
++                    }
++
++                    ipv6_buf[0] = '[';
++                    ngx_memcpy(ipv6_buf + 1, u.url.data, u.url.len);
++                    ipv6_buf[u.url.len + 1] = ']';
++
++                    u.url.data = ipv6_buf;
++                    u.url.len = u.url.len + 2;
++                }
++
++                if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
++                    if (u.err) {
++                        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                           "%s in resolver \"%V\"",
++                                           u.err, &u.url);
++                    }
++
++                    return NGX_ERROR;
++                }
++
++                rec = ngx_array_push_n(&r->connections, u.naddrs);
++                if (rec == NULL) {
++                    return NGX_ERROR;
++                }
++
++                ngx_memzero(rec, u.naddrs * sizeof(ngx_resolver_connection_t));
++
++                for (j = 0; j < u.naddrs; j++) {
++                    rec[j].sockaddr = u.addrs[j].sockaddr;
++                    rec[j].socklen = u.addrs[j].socklen;
++                    rec[j].server = u.addrs[j].name;
++                    rec[j].resolver = r;
++                }
++
++                total++;
++
++#if (NGX_DEBUG)
++                /*
++                 * logs with level below NGX_LOG_NOTICE will not be printed
++                 * in this early phase
++                 */
++                ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
++                                   "parsed a resolver: \"%V\"", &u.url);
++#endif
++
++                state = sw_nameserver;
++            }
++
++            break;
++
++        case sw_skip:
++            if (buf[i] == CR || buf[i] == LF) {
++                state = sw_nameserver;
++            }
++
++            break;
++        }
++
++        i++;
++    }
++
++    return NGX_OK;
++}
++#endif
++
++
+ ngx_resolver_t *
+ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+ {
+@@ -246,6 +445,39 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+         }
+ #endif
+ 
++#if !(NGX_WIN32)
++        if (ngx_strncmp(names[i].data, "local=", 6) == 0) {
++
++            if (ngx_strcmp(&names[i].data[6], "on") == 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  (u_char *)
++                                                  NGX_RESOLVER_FILE_NAME,
++                                                  sizeof(NGX_RESOLVER_FILE_NAME)
++                                                  - 1)
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            } else if (ngx_strcmp(&names[i].data[6], "off") != 0) {
++                if (ngx_resolver_read_resolv_conf(cf, r,
++                                                  &names[i].data[6],
++                                                  names[i].len - 6)
++                    != NGX_OK)
++                {
++                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                       "unable to parse local resolver");
++                    return NULL;
++                }
++
++            }
++
++            continue;
++        }
++#endif
++
+         ngx_memzero(&u, sizeof(ngx_url_t));
+ 
+         u.url = names[i];

--- a/patches/nginx-1.25.4-reuseport_close_unused_fds.patch
+++ b/patches/nginx-1.25.4-reuseport_close_unused_fds.patch
@@ -1,0 +1,38 @@
+diff --git a/src/core/ngx_connection.c b/src/core/ngx_connection.c
+--- a/src/core/ngx_connection.c
++++ b/src/core/ngx_connection.c
+@@ -1118,6 +1118,12 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
+     ls = cycle->listening.elts;
+     for (i = 0; i < cycle->listening.nelts; i++) {
+ 
++#if (NGX_HAVE_REUSEPORT)
++        if (ls[i].fd == (ngx_socket_t) -1) {
++            continue;
++        }
++#endif
++
+         c = ls[i].connection;
+ 
+         if (c) {
+diff --git a/src/event/ngx_event.c b/src/event/ngx_event.c
+--- a/src/event/ngx_event.c
++++ b/src/event/ngx_event.c
+@@ -775,6 +775,18 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+ #if (NGX_HAVE_REUSEPORT)
+         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
++            ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                           "closing unused fd:%d listening on %V",
++                           ls[i].fd, &ls[i].addr_text);
++
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++
+             continue;
+         }
+ #endif

--- a/patches/nginx-1.25.4-safe_resolver_ipv6_option.patch
+++ b/patches/nginx-1.25.4-safe_resolver_ipv6_option.patch
@@ -1,0 +1,60 @@
+# HG changeset patch
+# User Thibault Charbonnier <thibaultcha@fastmail.com>
+# Date 1481847421 28800
+#      Thu Dec 15 16:17:01 2016 -0800
+# Node ID 8bf038fe006fd8ae253d6b41fc6cf109a8912d3e
+# Parent  a3dc657f4e9530623683e6b85bd7492662e4dc47
+Resolver: ignore ipv6=off resolver option when no ipv6 support
+
+Makes the resolver directive more robust: we only error out when ipv6
+resolution is desired but not supported (ipv6=on).
+
+use case 1: some configurations are sometimes re-used between builds with and
+without ipv6 support. This patch avoids the need to remove the "ipv6=off" flag.
+
+use case 2: currently, some tools rely on the --with-ipv6 configure option from
+"nginx -V" to determine if ipv6 resolution should be disabled in some cases.
+With this option disappearing in Nginx 1.11.5, this patch would allow such tools
+to assume "ipv6=off" to be safe regardless of ipv6 support in the current
+build.
+
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index dade1846..5a3f0aa4 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -425,7 +425,6 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+             continue;
+         }
+ 
+-#if (NGX_HAVE_INET6)
+         if (ngx_strncmp(names[i].data, "ipv4=", 5) == 0) {
+ 
+             if (ngx_strcmp(&names[i].data[5], "on") == 0) {
+@@ -446,10 +445,19 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+         if (ngx_strncmp(names[i].data, "ipv6=", 5) == 0) {
+ 
+             if (ngx_strcmp(&names[i].data[5], "on") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 1;
++#else
++                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                   "no ipv6 support but \"%V\" in resolver",
++                                   &names[i]);
++                return NULL;
++#endif
+ 
+             } else if (ngx_strcmp(&names[i].data[5], "off") == 0) {
++#if (NGX_HAVE_INET6)
+                 r->ipv6 = 0;
++#endif
+ 
+             } else {
+                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+@@ -459,7 +467,6 @@ ngx_resolver_create(ngx_conf_t *cf, ngx_str_t *names, ngx_uint_t n)
+ 
+             continue;
+         }
+-#endif
+ 
+ #if !(NGX_WIN32)
+         if (ngx_strncmp(names[i].data, "local=", 6) == 0) {

--- a/patches/nginx-1.25.4-server_header.patch
+++ b/patches/nginx-1.25.4-server_header.patch
@@ -1,0 +1,39 @@
+diff --git a/src/core/nginx.h b/src/core/nginx.h
+index a3c0ef8..1263881 100644
+--- a/src/core/nginx.h
++++ b/src/core/nginx.h
+@@ -11,7 +11,7 @@
+ 
+ #define nginx_version      1025003
+ #define NGINX_VERSION      "1.25.4"
+-#define NGINX_VER          "nginx/" NGINX_VERSION
++#define NGINX_VER          "openresty/" NGINX_VERSION ".unknown"
+ 
+ #ifdef NGX_BUILD
+ #define NGINX_VER_BUILD    NGINX_VER " (" NGX_BUILD ")"
+diff --git a/src/http/ngx_http_header_filter_module.c b/src/http/ngx_http_header_filter_module.c
+index 9b89405..ca13f2a 100644
+--- a/src/http/ngx_http_header_filter_module.c
++++ b/src/http/ngx_http_header_filter_module.c
+@@ -46,7 +46,7 @@ ngx_module_t  ngx_http_header_filter_module = {
+ };
+ 
+ 
+-static u_char ngx_http_server_string[] = "Server: nginx" CRLF;
++static u_char ngx_http_server_string[] = "Server: openresty" CRLF;
+ static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
+ static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
+ 
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 8621e7a..a76c677 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -143,7 +143,7 @@ ngx_http_v2_header_filter(ngx_http_request_t *r)
+     ngx_http_core_srv_conf_t  *cscf;
+     u_char                     addr[NGX_SOCKADDR_STRLEN];
+ 
+-    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
++    static const u_char nginx[8] = "\x87\x3d\x65\xaa\xc2\xa1\x3e\xbf";
+ #if (NGX_HTTP_GZIP)
+     static const u_char accept_encoding[12] =
+         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";

--- a/patches/nginx-1.25.4-setting_args_invalidates_uri.patch
+++ b/patches/nginx-1.25.4-setting_args_invalidates_uri.patch
@@ -1,0 +1,44 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@gmail.com>
+# Date 1390506359 28800
+# Node ID 17186b98c235c07e94c64e5853689f790f173756
+# Parent  4b50d1f299d8a69f3e3f7975132e1490352642fe
+Variable: setting $args should invalidate unparsed uri.
+
+diff -r 4b50d1f299d8 -r 17186b98c235 src/http/ngx_http_variables.c
+--- a/src/http/ngx_http_variables.c	Fri Jan 10 11:22:14 2014 -0800
++++ b/src/http/ngx_http_variables.c	Thu Jan 23 11:45:59 2014 -0800
+@@ -15,6 +15,8 @@
+     ngx_http_variable_value_t *v, uintptr_t data);
+ static void ngx_http_variable_request_set(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data);
++static void ngx_http_variable_request_args_set(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data);
+ static ngx_int_t ngx_http_variable_request_get_size(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data);
+ static void ngx_http_variable_request_set_size(ngx_http_request_t *r,
+@@ -218,7 +220,7 @@
+       NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
+     { ngx_string("args"),
+-      ngx_http_variable_request_set,
++      ngx_http_variable_request_args_set,
+       ngx_http_variable_request,
+       offsetof(ngx_http_request_t, args),
+       NGX_HTTP_VAR_CHANGEABLE|NGX_HTTP_VAR_NOCACHEABLE, 0 },
+@@ -647,6 +649,15 @@
+ 
+ 
+ static void
++ngx_http_variable_request_args_set(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data)
++{
++    r->valid_unparsed_uri = 0;
++    ngx_http_variable_request_set(r, v, data);
++}
++
++
++static void
+ ngx_http_variable_request_set(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data)
+ {

--- a/patches/nginx-1.25.4-single_process_graceful_exit.patch
+++ b/patches/nginx-1.25.4-single_process_graceful_exit.patch
@@ -1,0 +1,75 @@
+diff --git a/src/os/unix/ngx_process.c b/src/os/unix/ngx_process.c
+index 15680237..12a8c687 100644
+--- a/src/os/unix/ngx_process.c
++++ b/src/os/unix/ngx_process.c
+@@ -362,8 +362,15 @@ ngx_signal_handler(int signo, siginfo_t *siginfo, void *ucontext)
+             break;
+ 
+         case ngx_signal_value(NGX_RECONFIGURE_SIGNAL):
+-            ngx_reconfigure = 1;
+-            action = ", reconfiguring";
++            if (ngx_process == NGX_PROCESS_SINGLE) {
++                ngx_terminate = 1;
++                action = ", exiting";
++
++            } else {
++                ngx_reconfigure = 1;
++                action = ", reconfiguring";
++            }
++
+             break;
+ 
+         case ngx_signal_value(NGX_REOPEN_SIGNAL):
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index 5817a2c2..f3d58e97 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -305,11 +305,26 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+     }
+ 
+     for ( ;; ) {
++        if (ngx_exiting) {
++            if (ngx_event_no_timers_left() == NGX_OK) {
++                ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
++
++                for (i = 0; cycle->modules[i]; i++) {
++                    if (cycle->modules[i]->exit_process) {
++                        cycle->modules[i]->exit_process(cycle);
++                    }
++                }
++
++                ngx_master_process_exit(cycle);
++            }
++        }
++
+         ngx_log_debug0(NGX_LOG_DEBUG_EVENT, cycle->log, 0, "worker cycle");
+ 
+         ngx_process_events_and_timers(cycle);
+ 
+-        if (ngx_terminate || ngx_quit) {
++        if (ngx_terminate) {
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
+ 
+             for (i = 0; cycle->modules[i]; i++) {
+                 if (cycle->modules[i]->exit_process) {
+@@ -320,6 +335,20 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+             ngx_master_process_exit(cycle);
+         }
+ 
++        if (ngx_quit) {
++            ngx_quit = 0;
++            ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
++                          "gracefully shutting down");
++            ngx_setproctitle("process is shutting down");
++
++            if (!ngx_exiting) {
++                ngx_exiting = 1;
++                ngx_set_shutdown_timer(cycle);
++                ngx_close_listening_sockets(cycle);
++                ngx_close_idle_connections(cycle);
++            }
++        }
++
+         if (ngx_reconfigure) {
+             ngx_reconfigure = 0;
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reconfiguring");

--- a/patches/nginx-1.25.4-socket_cloexec.patch
+++ b/patches/nginx-1.25.4-socket_cloexec.patch
@@ -1,0 +1,185 @@
+diff --git a/auto/unix b/auto/unix
+index 10835f6c..b5b33bb3 100644
+--- a/auto/unix
++++ b/auto/unix
+@@ -990,3 +990,27 @@ ngx_feature_test='struct addrinfo *res;
+                   if (getaddrinfo("localhost", NULL, NULL, &res) != 0) return 1;
+                   freeaddrinfo(res)'
+ . auto/feature
++
++ngx_feature="SOCK_CLOEXEC support"
++ngx_feature_name="NGX_HAVE_SOCKET_CLOEXEC"
++ngx_feature_run=no
++ngx_feature_incs="#include <sys/types.h>
++                  #include <sys/socket.h>"
++ngx_feature_path=
++ngx_feature_libs=
++ngx_feature_test="int fd;
++                  fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);"
++. auto/feature
++
++ngx_feature="FD_CLOEXEC support"
++ngx_feature_name="NGX_HAVE_FD_CLOEXEC"
++ngx_feature_run=no
++ngx_feature_incs="#include <sys/types.h>
++                  #include <sys/socket.h>
++                  #include <fcntl.h>"
++ngx_feature_path=
++ngx_feature_libs=
++ngx_feature_test="int fd;
++                  fd = socket(AF_INET, SOCK_STREAM, 0);
++                  fcntl(fd, F_SETFD, FD_CLOEXEC);"
++. auto/feature
+diff --git a/src/core/ngx_resolver.c b/src/core/ngx_resolver.c
+index cd55520c..438e0806 100644
+--- a/src/core/ngx_resolver.c
++++ b/src/core/ngx_resolver.c
+@@ -4466,8 +4466,14 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
+     ngx_event_t       *rev, *wev;
+     ngx_connection_t  *c;
+ 
++#if (NGX_HAVE_SOCKET_CLOEXEC)
++    s = ngx_socket(rec->sockaddr->sa_family, SOCK_STREAM | SOCK_CLOEXEC, 0);
++
++#else
+     s = ngx_socket(rec->sockaddr->sa_family, SOCK_STREAM, 0);
+ 
++#endif
++
+     ngx_log_debug1(NGX_LOG_DEBUG_EVENT, &rec->log, 0, "TCP socket %d", s);
+ 
+     if (s == (ngx_socket_t) -1) {
+@@ -4494,6 +4500,15 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
+         goto failed;
+     }
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++    if (ngx_cloexec(s) == -1) {
++        ngx_log_error(NGX_LOG_ALERT, &rec->log, ngx_socket_errno,
++                      ngx_cloexec_n " failed");
++
++        goto failed;
++    }
++#endif
++
+     rev = c->read;
+     wev = c->write;
+ 
+diff --git a/src/event/ngx_event.h b/src/event/ngx_event.h
+index 19fec68..8c2f01a 100644
+--- a/src/event/ngx_event.h
++++ b/src/event/ngx_event.h
+@@ -73,6 +73,9 @@ struct ngx_event_s {
+     /* to test on worker exit */
+     unsigned         channel:1;
+     unsigned         resolver:1;
++#if (HAVE_SOCKET_CLOEXEC_PATCH)
++    unsigned         skip_socket_leak_check:1;
++#endif
+ 
+     unsigned         cancelable:1;
+ 
+diff --git a/src/event/ngx_event_accept.c b/src/event/ngx_event_accept.c
+index 77563709..5827b9d0 100644
+--- a/src/event/ngx_event_accept.c
++++ b/src/event/ngx_event_accept.c
+@@ -62,7 +62,9 @@ ngx_event_accept(ngx_event_t *ev)
+ 
+ #if (NGX_HAVE_ACCEPT4)
+         if (use_accept4) {
+-            s = accept4(lc->fd, &sa.sockaddr, &socklen, SOCK_NONBLOCK);
++            s = accept4(lc->fd, &sa.sockaddr, &socklen,
++                        SOCK_NONBLOCK | SOCK_CLOEXEC);
++
+         } else {
+             s = accept(lc->fd, &sa.sockaddr, &socklen);
+         }
+@@ -202,6 +204,16 @@ ngx_event_accept(ngx_event_t *ev)
+                     ngx_close_accepted_connection(c);
+                     return;
+                 }
++
++#if (NGX_HAVE_FD_CLOEXEC)
++                if (ngx_cloexec(s) == -1) {
++                    ngx_log_error(NGX_LOG_ALERT, ev->log, ngx_socket_errno,
++                                  ngx_cloexec_n " failed");
++                    ngx_close_accepted_connection(c);
++                    return;
++                }
++#endif
++
+             }
+         }
+ 
+diff --git a/src/event/ngx_event_connect.c b/src/event/ngx_event_connect.c
+index c5bb8068..cf33b1d2 100644
+--- a/src/event/ngx_event_connect.c
++++ b/src/event/ngx_event_connect.c
+@@ -38,8 +38,15 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
+ 
+     type = (pc->type ? pc->type : SOCK_STREAM);
+ 
++#if (NGX_HAVE_SOCKET_CLOEXEC)
++    s = ngx_socket(pc->sockaddr->sa_family, type | SOCK_CLOEXEC, 0);
++
++#else
+     s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+ 
++#endif
++
++
+     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
+                    (type == SOCK_STREAM) ? "stream" : "dgram", s);
+ 
+@@ -80,6 +87,15 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
+         goto failed;
+     }
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++    if (ngx_cloexec(s) == -1) {
++        ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
++                      ngx_cloexec_n " failed");
++
++        goto failed;
++    }
++#endif
++
+     if (pc->local) {
+ 
+ #if (NGX_HAVE_TRANSPARENT_PROXY)
+diff --git a/src/os/unix/ngx_process_cycle.c b/src/os/unix/ngx_process_cycle.c
+index c4376a5..48e8fa8 100644
+--- a/src/os/unix/ngx_process_cycle.c
++++ b/src/os/unix/ngx_process_cycle.c
+@@ -960,6 +1029,9 @@ ngx_worker_process_exit(ngx_cycle_t *cycle)
+         for (i = 0; i < cycle->connection_n; i++) {
+             if (c[i].fd != -1
+                 && c[i].read
++#if (HAVE_SOCKET_CLOEXEC_PATCH)
++                && !c[i].read->skip_socket_leak_check
++#endif
+                 && !c[i].read->accept
+                 && !c[i].read->channel
+                 && !c[i].read->resolver)
+diff --git a/src/os/unix/ngx_socket.h b/src/os/unix/ngx_socket.h
+index fcc51533..d1eebf47 100644
+--- a/src/os/unix/ngx_socket.h
++++ b/src/os/unix/ngx_socket.h
+@@ -38,6 +38,17 @@ int ngx_blocking(ngx_socket_t s);
+ 
+ #endif
+ 
++#if (NGX_HAVE_FD_CLOEXEC)
++
++#define ngx_cloexec(s)      fcntl(s, F_SETFD, FD_CLOEXEC)
++#define ngx_cloexec_n       "fcntl(FD_CLOEXEC)"
++
++/* at least FD_CLOEXEC is required to ensure connection fd is closed
++ * after execve */
++#define HAVE_SOCKET_CLOEXEC_PATCH  1
++
++#endif
++
+ int ngx_tcp_nopush(ngx_socket_t s);
+ int ngx_tcp_push(ngx_socket_t s);
+ 

--- a/patches/nginx-1.25.4-ssl_cert_cb_yield.patch
+++ b/patches/nginx-1.25.4-ssl_cert_cb_yield.patch
@@ -1,0 +1,64 @@
+# HG changeset patch
+# User Yichun Zhang <agentzh@openresty.org>
+# Date 1451762084 28800
+#      Sat Jan 02 11:14:44 2016 -0800
+# Node ID 449f0461859c16e95bdb18e8be6b94401545d3dd
+# Parent  78b4e10b4367b31367aad3c83c9c3acdd42397c4
+SSL: handled SSL_CTX_set_cert_cb() callback yielding.
+
+OpenSSL 1.0.2+ introduces SSL_CTX_set_cert_cb() to allow custom
+callbacks to serve the SSL certificiates and private keys dynamically
+and lazily. The callbacks may yield for nonblocking I/O or sleeping.
+Here we added support for such usage in NGINX 3rd-party modules
+(like ngx_lua) in NGINX's event handlers for downstream SSL
+connections.
+
+diff -r 78b4e10b4367 -r 449f0461859c src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c Thu Dec 17 16:39:15 2015 +0300
++++ b/src/event/ngx_event_openssl.c Sat Jan 02 11:14:44 2016 -0800
+@@ -1445,6 +1445,23 @@ ngx_ssl_handshake(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;
+@@ -1558,6 +1575,21 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/patches/nginx-1.25.4-ssl_client_hello_cb_yield.patch
+++ b/patches/nginx-1.25.4-ssl_client_hello_cb_yield.patch
@@ -1,0 +1,38 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index 8ba30e58..2b2db95c 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1712,6 +1712,9 @@ ngx_ssl_handshake(ngx_connection_t *c)
+     if (sslerr == SSL_ERROR_WANT_X509_LOOKUP
+ #   ifdef SSL_ERROR_PENDING_SESSION
+         || sslerr == SSL_ERROR_PENDING_SESSION
++#   endif
++#   ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
++        || sslerr == SSL_ERROR_WANT_CLIENT_HELLO_CB
+ #   endif
+        )
+     {
+@@ -1889,6 +1892,23 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+     }
+ #endif
+ 
++#ifdef SSL_ERROR_WANT_CLIENT_HELLO_CB
++    if (sslerr == SSL_ERROR_WANT_CLIENT_HELLO_CB) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/patches/nginx-1.25.4-ssl_sess_cb_yield.patch
+++ b/patches/nginx-1.25.4-ssl_sess_cb_yield.patch
@@ -1,0 +1,41 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -1446,7 +1446,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
+     }
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x10002000L
+-    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP) {
++    if (sslerr == SSL_ERROR_WANT_X509_LOOKUP
++#   ifdef SSL_ERROR_PENDING_SESSION
++        || sslerr == SSL_ERROR_PENDING_SESSION
++#   endif
++       )
++    {
+         c->read->handler = ngx_ssl_handshake_handler;
+         c->write->handler = ngx_ssl_handshake_handler;
+ 
+@@ -1575,6 +1580,23 @@ ngx_ssl_try_early_data(ngx_connection_t *c)
+         return NGX_AGAIN;
+     }
+ 
++#ifdef SSL_ERROR_PENDING_SESSION
++    if (sslerr == SSL_ERROR_PENDING_SESSION) {
++        c->read->handler = ngx_ssl_handshake_handler;
++        c->write->handler = ngx_ssl_handshake_handler;
++
++        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        if (ngx_handle_write_event(c->write, 0) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        return NGX_AGAIN;
++    }
++#endif
++
+     err = (sslerr == SSL_ERROR_SYSCALL) ? ngx_errno : 0;
+ 
+     c->ssl->no_wait_shutdown = 1;

--- a/patches/nginx-1.25.4-stream_balancer_export.patch
+++ b/patches/nginx-1.25.4-stream_balancer_export.patch
@@ -1,0 +1,53 @@
+diff --git a/src/stream/ngx_stream_upstream_round_robin.c b/src/stream/ngx_stream_upstream_round_robin.c
+index 526de3a..b531ce1 100644
+--- a/src/stream/ngx_stream_upstream_round_robin.c
++++ b/src/stream/ngx_stream_upstream_round_robin.c
+@@ -21,10 +21,6 @@ static void ngx_stream_upstream_notify_round_robin_peer(
+ 
+ #if (NGX_STREAM_SSL)
+ 
+-static ngx_int_t ngx_stream_upstream_set_round_robin_peer_session(
+-    ngx_peer_connection_t *pc, void *data);
+-static void ngx_stream_upstream_save_round_robin_peer_session(
+-    ngx_peer_connection_t *pc, void *data);
+ static ngx_int_t ngx_stream_upstream_empty_set_session(
+     ngx_peer_connection_t *pc, void *data);
+ static void ngx_stream_upstream_empty_save_session(ngx_peer_connection_t *pc,
+@@ -690,7 +686,7 @@ ngx_stream_upstream_notify_round_robin_peer(ngx_peer_connection_t *pc,
+ 
+ #if (NGX_STREAM_SSL)
+ 
+-static ngx_int_t
++ngx_int_t
+ ngx_stream_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
+     void *data)
+ {
+@@ -756,7 +752,7 @@ ngx_stream_upstream_set_round_robin_peer_session(ngx_peer_connection_t *pc,
+ }
+ 
+ 
+-static void
++void
+ ngx_stream_upstream_save_round_robin_peer_session(ngx_peer_connection_t *pc,
+     void *data)
+ {
+diff --git a/src/stream/ngx_stream_upstream_round_robin.h b/src/stream/ngx_stream_upstream_round_robin.h
+index 35d9fce..75f3e31 100644
+--- a/src/stream/ngx_stream_upstream_round_robin.h
++++ b/src/stream/ngx_stream_upstream_round_robin.h
+@@ -142,5 +142,15 @@ ngx_int_t ngx_stream_upstream_get_round_robin_peer(ngx_peer_connection_t *pc,
+ void ngx_stream_upstream_free_round_robin_peer(ngx_peer_connection_t *pc,
+     void *data, ngx_uint_t state);
+ 
++#if (NGX_STREAM_SSL)
++ngx_int_t ngx_stream_upstream_set_round_robin_peer_session(
++    ngx_peer_connection_t *pc, void *data);
++void ngx_stream_upstream_save_round_robin_peer_session(
++    ngx_peer_connection_t *pc, void *data);
++#endif
++
++
++#define HAVE_NGX_STREAM_BALANCER_EXPORT_PATCH 1
++
+ 
+ #endif /* _NGX_STREAM_UPSTREAM_ROUND_ROBIN_H_INCLUDED_ */

--- a/patches/nginx-1.25.4-stream_proxy_get_next_upstream_tries.patch
+++ b/patches/nginx-1.25.4-stream_proxy_get_next_upstream_tries.patch
@@ -1,0 +1,31 @@
+diff --git a/src/stream/ngx_stream.h b/src/stream/ngx_stream.h
+index 09d2459..de92724 100644
+--- a/src/stream/ngx_stream.h
++++ b/src/stream/ngx_stream.h
+@@ -303,4 +303,7 @@ typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
+ extern ngx_stream_filter_pt  ngx_stream_top_filter;
+ 
+ 
++#define HAS_NGX_STREAM_PROXY_GET_NEXT_UPSTREAM_TRIES_PATCH 1
++
++
+ #endif /* _NGX_STREAM_H_INCLUDED_ */
+diff --git a/src/stream/ngx_stream_proxy_module.c b/src/stream/ngx_stream_proxy_module.c
+index 0afde1c..3254ce1 100644
+--- a/src/stream/ngx_stream_proxy_module.c
++++ b/src/stream/ngx_stream_proxy_module.c
+@@ -2156,3 +2156,14 @@ ngx_stream_proxy_bind(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ 
+     return NGX_CONF_OK;
+ }
++
++
++ngx_uint_t
++ngx_stream_proxy_get_next_upstream_tries(ngx_stream_session_t *s)
++{
++    ngx_stream_proxy_srv_conf_t      *pscf;
++
++    pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
++
++    return pscf->next_upstream_tries;
++}

--- a/patches/nginx-1.25.4-stream_proxy_timeout_fields.patch
+++ b/patches/nginx-1.25.4-stream_proxy_timeout_fields.patch
@@ -1,0 +1,178 @@
+diff -u -r -p -Naur nginx-1.25.4/src/stream/ngx_stream.h nginx-1.25.4-patched/src/stream/ngx_stream.h
+--- nginx-1.25.4/src/stream/ngx_stream.h	2021-11-04 21:27:55.288708527 +0800
++++ nginx-1.25.4-patched/src/stream/ngx_stream.h	2021-11-04 21:28:50.768035209 +0800
+@@ -254,6 +254,15 @@ typedef struct {
+ } ngx_stream_module_t;
+ 
+ 
++typedef struct {
++    ngx_msec_t                       connect_timeout;
++    ngx_msec_t                       timeout;
++} ngx_stream_proxy_ctx_t;
++
++
++#define NGX_STREAM_HAVE_PROXY_TIMEOUT_FIELDS_PATCH 1
++
++
+ #define NGX_STREAM_MODULE       0x4d525453     /* "STRM" */
+ 
+ #define NGX_STREAM_MAIN_CONF    0x02000000
+@@ -307,6 +316,7 @@ void ngx_stream_finalize_session(ngx_str
+ extern ngx_module_t  ngx_stream_module;
+ extern ngx_uint_t    ngx_stream_max_module;
+ extern ngx_module_t  ngx_stream_core_module;
++extern ngx_module_t  ngx_stream_proxy_module;
+ 
+ 
+ typedef ngx_int_t (*ngx_stream_filter_pt)(ngx_stream_session_t *s,
+diff -u -r -p -Naur nginx-1.25.4/src/stream/ngx_stream_proxy_module.c nginx-1.25.4-patched/src/stream/ngx_stream_proxy_module.c
+--- nginx-1.25.4/src/stream/ngx_stream_proxy_module.c	2021-11-04 21:27:55.289708533 +0800
++++ nginx-1.25.4-patched/src/stream/ngx_stream_proxy_module.c	2021-11-04 21:37:03.578936990 +0800
+@@ -400,6 +400,7 @@ ngx_stream_proxy_handler(ngx_stream_sess
+     ngx_stream_proxy_srv_conf_t      *pscf;
+     ngx_stream_upstream_srv_conf_t   *uscf, **uscfp;
+     ngx_stream_upstream_main_conf_t  *umcf;
++    ngx_stream_proxy_ctx_t           *pctx;
+ 
+     c = s->connection;
+ 
+@@ -408,6 +409,17 @@ ngx_stream_proxy_handler(ngx_stream_sess
+     ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+                    "proxy connection handler");
+ 
++    pctx = ngx_palloc(c->pool, sizeof(ngx_stream_proxy_ctx_t));
++    if (pctx == NULL) {
++        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
++        return;
++    }
++
++    pctx->connect_timeout = pscf->connect_timeout;
++    pctx->timeout = pscf->timeout;
++
++    ngx_stream_set_ctx(s, pctx, ngx_stream_proxy_module);
++
+     u = ngx_pcalloc(c->pool, sizeof(ngx_stream_upstream_t));
+     if (u == NULL) {
+         ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+@@ -699,6 +711,7 @@ ngx_stream_proxy_connect(ngx_stream_sess
+     ngx_connection_t             *c, *pc;
+     ngx_stream_upstream_t        *u;
+     ngx_stream_proxy_srv_conf_t  *pscf;
++    ngx_stream_proxy_ctx_t       *ctx;
+ 
+     c = s->connection;
+ 
+@@ -706,6 +719,8 @@ ngx_stream_proxy_connect(ngx_stream_sess
+ 
+     pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+ 
++    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
++
+     u = s->upstream;
+ 
+     u->connected = 0;
+@@ -774,7 +789,7 @@ ngx_stream_proxy_connect(ngx_stream_sess
+     pc->read->handler = ngx_stream_proxy_connect_handler;
+     pc->write->handler = ngx_stream_proxy_connect_handler;
+ 
+-    ngx_add_timer(pc->write, pscf->connect_timeout);
++    ngx_add_timer(pc->write, ctx->connect_timeout);
+ }
+ 
+ 
+@@ -957,12 +957,14 @@ ngx_stream_proxy_init_upstream(ngx_stream_session_t *s)
+ static ngx_int_t
+ ngx_stream_proxy_send_proxy_protocol(ngx_stream_session_t *s)
+ {
+-    u_char                       *p;
+-    ssize_t                       n, size;
+-    ngx_connection_t             *c, *pc;
+-    ngx_stream_upstream_t        *u;
+-    ngx_stream_proxy_srv_conf_t  *pscf;
+-    u_char                        buf[NGX_PROXY_PROTOCOL_V1_MAX_HEADER];
++    u_char                  *p;
++    u_char                   buf[NGX_PROXY_PROTOCOL_V1_MAX_HEADER];
++    ssize_t                  n, size;
++    ngx_connection_t        *c, *pc;
++    ngx_stream_upstream_t   *u;
++    ngx_stream_proxy_ctx_t  *ctx;
++
++    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
+ 
+     c = s->connection;
+ 
+@@ -976,9 +993,7 @@ ngx_stream_proxy_send_proxy_protocol(ngx
+             return NGX_ERROR;
+         }
+ 
+-        pscf = ngx_stream_get_module_srv_conf(s, ngx_stream_proxy_module);
+-
+-        ngx_add_timer(pc->write, pscf->timeout);
++        ngx_add_timer(pc->write, ctx->timeout);
+ 
+         pc->write->handler = ngx_stream_proxy_connect_handler;
+ 
+@@ -1053,6 +1068,9 @@ ngx_stream_proxy_ssl_init_connection(ngx
+     ngx_connection_t             *pc;
+     ngx_stream_upstream_t        *u;
+     ngx_stream_proxy_srv_conf_t  *pscf;
++    ngx_stream_proxy_ctx_t       *ctx;
++
++    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
+ 
+     u = s->upstream;
+ 
+@@ -1099,7 +1117,7 @@ ngx_stream_proxy_ssl_init_connection(ngx
+     if (rc == NGX_AGAIN) {
+ 
+         if (!pc->write->timer_set) {
+-            ngx_add_timer(pc->write, pscf->connect_timeout);
++            ngx_add_timer(pc->write, ctx->connect_timeout);
+         }
+ 
+         pc->ssl->handler = ngx_stream_proxy_ssl_handshake;
+@@ -1408,6 +1426,7 @@ ngx_stream_proxy_process_connection(ngx_
+     ngx_stream_session_t         *s;
+     ngx_stream_upstream_t        *u;
+     ngx_stream_proxy_srv_conf_t  *pscf;
++    ngx_stream_proxy_ctx_t       *ctx;
+ 
+     c = ev->data;
+     s = c->data;
+@@ -1419,6 +1438,8 @@ ngx_stream_proxy_process_connection(ngx_
+         return;
+     }
+ 
++    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
++
+     c = s->connection;
+     pc = u->peer.connection;
+ 
+@@ -1438,7 +1459,7 @@ ngx_stream_proxy_process_connection(ngx_
+                 }
+ 
+                 if (u->connected && !c->read->delayed && !pc->read->delayed) {
+-                    ngx_add_timer(c->write, pscf->timeout);
++                    ngx_add_timer(c->write, ctx->timeout);
+                 }
+ 
+                 return;
+@@ -1600,6 +1621,9 @@ ngx_stream_proxy_process(ngx_stream_sess
+     ngx_log_handler_pt            handler;
+     ngx_stream_upstream_t        *u;
+     ngx_stream_proxy_srv_conf_t  *pscf;
++    ngx_stream_proxy_ctx_t       *ctx;
++
++    ctx = ngx_stream_get_module_ctx(s, ngx_stream_proxy_module);
+ 
+     u = s->upstream;
+ 
+@@ -1807,7 +1831,7 @@ ngx_stream_proxy_process(ngx_stream_sess
+         }
+ 
+         if (!c->read->delayed && !pc->read->delayed) {
+-            ngx_add_timer(c->write, pscf->timeout);
++            ngx_add_timer(c->write, ctx->timeout);
+ 
+         } else if (c->write->timer_set) {
+             ngx_del_timer(c->write);

--- a/patches/nginx-1.25.4-stream_ssl_preread_no_skip.patch
+++ b/patches/nginx-1.25.4-stream_ssl_preread_no_skip.patch
@@ -1,0 +1,13 @@
+diff --git a/src/stream/ngx_stream_ssl_preread_module.c b/src/stream/ngx_stream_ssl_preread_module.c
+index e3d11fd9..3717b5fe 100644
+--- a/src/stream/ngx_stream_ssl_preread_module.c
++++ b/src/stream/ngx_stream_ssl_preread_module.c
+@@ -159,7 +159,7 @@ ngx_stream_ssl_preread_handler(ngx_stream_session_t *s)
+ 
+         rc = ngx_stream_ssl_preread_parse_record(ctx, p, p + len);
+         if (rc != NGX_AGAIN) {
+-            return rc;
++            return rc == NGX_OK ? NGX_DECLINED : rc;
+         }
+ 
+         p += len;

--- a/patches/nginx-1.25.4-upstream_pipelining.patch
+++ b/patches/nginx-1.25.4-upstream_pipelining.patch
@@ -1,0 +1,23 @@
+commit f9907b72a76a21ac5413187b83177a919475c75f
+Author: Yichun Zhang (agentzh) <agentzh@gmail.com>
+Date:   Wed Feb 10 16:05:08 2016 -0800
+
+    bugfix: upstream: keep sending request data after the first write attempt.
+    
+    See
+    http://mailman.nginx.org/pipermail/nginx-devel/2012-March/002040.html
+    for more details on the issue.
+
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 69019417..92b7c97f 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -2239,7 +2239,7 @@ ngx_http_upstream_send_request_handler(ngx_http_request_t *r,
+
+ #endif
+
+-    if (u->header_sent && !u->conf->preserve_output) {
++    if (u->request_body_sent && !u->conf->preserve_output) {
+         u->write_event_handler = ngx_http_upstream_dummy_handler;
+
+         (void) ngx_handle_write_event(c->write, 0);

--- a/patches/nginx-1.25.4-upstream_timeout_fields.patch
+++ b/patches/nginx-1.25.4-upstream_timeout_fields.patch
@@ -1,0 +1,112 @@
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 69019417..2265d8f7 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -509,12 +509,19 @@ void
+ ngx_http_upstream_init(ngx_http_request_t *r)
+ {
+     ngx_connection_t     *c;
++    ngx_http_upstream_t  *u;
+ 
+     c = r->connection;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                    "http init upstream, client timer: %d", c->read->timer_set);
+ 
++    u = r->upstream;
++
++    u->connect_timeout = u->conf->connect_timeout;
++    u->send_timeout = u->conf->send_timeout;
++    u->read_timeout = u->conf->read_timeout;
++
+ #if (NGX_HTTP_V2)
+     if (r->stream) {
+         ngx_http_upstream_init_request(r);
+@@ -1626,7 +1633,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+     u->request_body_blocked = 0;
+ 
+     if (rc == NGX_AGAIN) {
+-        ngx_add_timer(c->write, u->conf->connect_timeout);
++        ngx_add_timer(c->write, u->connect_timeout);
+         return;
+     }
+ 
+@@ -1704,7 +1711,7 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+     if (rc == NGX_AGAIN) {
+ 
+         if (!c->write->timer_set) {
+-            ngx_add_timer(c->write, u->conf->connect_timeout);
++            ngx_add_timer(c->write, u->connect_timeout);
+         }
+ 
+         c->ssl->handler = ngx_http_upstream_ssl_handshake_handler;
+@@ -2022,7 +2029,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (rc == NGX_AGAIN) {
+         if (!c->write->ready || u->request_body_blocked) {
+-            ngx_add_timer(c->write, u->conf->send_timeout);
++            ngx_add_timer(c->write, u->send_timeout);
+ 
+         } else if (c->write->timer_set) {
+             ngx_del_timer(c->write);
+@@ -2084,7 +2091,7 @@ ngx_http_upstream_send_request(ngx_http_request_t *r, ngx_http_upstream_t *u,
+             return;
+         }
+ 
+-        ngx_add_timer(c->read, u->conf->read_timeout);
++        ngx_add_timer(c->read, u->read_timeout);
+ 
+         if (c->read->ready) {
+             ngx_http_upstream_process_header(r, u);
+@@ -3213,7 +3220,7 @@ ngx_http_upstream_send_response(ngx_http_request_t *r, ngx_http_upstream_t *u)
+         p->cyclic_temp_file = 0;
+     }
+ 
+-    p->read_timeout = u->conf->read_timeout;
++    p->read_timeout = u->read_timeout;
+     p->send_timeout = clcf->send_timeout;
+     p->send_lowat = clcf->send_lowat;
+ 
+@@ -3458,7 +3465,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->write->active && !upstream->write->ready) {
+-        ngx_add_timer(upstream->write, u->conf->send_timeout);
++        ngx_add_timer(upstream->write, u->send_timeout);
+ 
+     } else if (upstream->write->timer_set) {
+         ngx_del_timer(upstream->write);
+@@ -3470,7 +3477,7 @@ ngx_http_upstream_process_upgraded(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+@@ -3664,7 +3671,7 @@ ngx_http_upstream_process_non_buffered_request(ngx_http_request_t *r,
+     }
+ 
+     if (upstream->read->active && !upstream->read->ready) {
+-        ngx_add_timer(upstream->read, u->conf->read_timeout);
++        ngx_add_timer(upstream->read, u->read_timeout);
+ 
+     } else if (upstream->read->timer_set) {
+         ngx_del_timer(upstream->read);
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index c2f4dc0b..b9eef118 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -333,6 +333,11 @@ struct ngx_http_upstream_s {
+     ngx_array_t                     *caches;
+ #endif
+ 
++#define HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS  1
++    ngx_msec_t                       connect_timeout;
++    ngx_msec_t                       send_timeout;
++    ngx_msec_t                       read_timeout;
++
+     ngx_http_upstream_headers_in_t   headers_in;
+ 
+     ngx_http_upstream_resolved_t    *resolved;

--- a/patches/nginx-1.25.4-win32_max_err_str.patch
+++ b/patches/nginx-1.25.4-win32_max_err_str.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os/win32/ngx_event_log.c b/src/os/win32/ngx_event_log.c
+index e11ed1e8..dce8eddd 100644
+--- a/src/os/win32/ngx_event_log.c
++++ b/src/os/win32/ngx_event_log.c
+@@ -8,7 +8,9 @@
+ #include <ngx_core.h>
+ 
+ 
+-#define NGX_MAX_ERROR_STR   2048
++#ifndef NGX_MAX_ERROR_STR
++#define NGX_MAX_ERROR_STR   4096
++#endif
+ 
+ 
+ void ngx_cdecl

--- a/t/000-sanity.t
+++ b/t/000-sanity.t
@@ -285,7 +285,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -324,7 +324,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -353,7 +353,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -375,7 +375,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -414,7 +414,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -443,7 +443,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -465,7 +465,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2 -O3' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -504,7 +504,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -533,7 +533,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -555,7 +555,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -594,7 +594,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -623,7 +623,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -645,7 +645,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -683,7 +683,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -712,7 +712,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -734,7 +734,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -772,7 +772,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -801,7 +801,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1074,7 +1074,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1114,7 +1114,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1143,7 +1143,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1165,7 +1165,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1205,7 +1205,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1234,7 +1234,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1269,7 +1269,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1309,7 +1309,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1338,7 +1338,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1360,7 +1360,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1399,7 +1399,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC='gcc-4.2'
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC='gcc-4.2'
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC='gcc-4.2'
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1428,7 +1428,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1452,7 +1452,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-debug \
   --with-cc-opt='-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -O2' \
@@ -1492,7 +1492,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1521,7 +1521,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1543,7 +1543,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-debug \
   --with-cc-opt='-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -O2' \
@@ -1583,7 +1583,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall -fpic" CC='cl'
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC='cl'
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC='cl'
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1612,7 +1612,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1649,7 +1649,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1689,7 +1689,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1718,7 +1718,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1740,7 +1740,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1780,7 +1780,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1809,7 +1809,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1862,7 +1862,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1901,7 +1901,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -1930,7 +1930,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -1952,7 +1952,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -1991,7 +1991,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2020,7 +2020,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2042,7 +2042,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2081,7 +2081,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2110,7 +2110,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2132,7 +2132,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2171,7 +2171,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2200,7 +2200,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2222,7 +2222,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2261,7 +2261,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2290,7 +2290,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2312,7 +2312,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2351,7 +2351,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2380,7 +2380,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2405,7 +2405,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2444,7 +2444,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib LDFLAGS='-bundle -undefined dynamic_lookup' CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2473,7 +2473,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2498,7 +2498,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-debug \
   --with-cc-opt='-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -O2' \
@@ -2538,7 +2538,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CFLAGS="-g -O -Wall -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CFLAGS="-g -O -Wall" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib INSTALL='$(INSTALL)' CFLAGS="-g -O -Wall" CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2567,7 +2567,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2589,7 +2589,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2627,7 +2627,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2655,7 +2655,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2677,7 +2677,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2716,7 +2716,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2743,7 +2743,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2765,7 +2765,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2804,7 +2804,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2832,7 +2832,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2854,7 +2854,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2892,7 +2892,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-cjson-2.1.0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_CMODULE_DIR=/usr/local/openresty/lualib LUA_MODULE_DIR=/usr/local/openresty/lualib CJSON_CFLAGS="-g -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -2919,7 +2919,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -2941,7 +2941,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -2978,7 +2978,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/LuaJIT-2.1-20231117 && $(MAKE) TARGET_STRIP=@: CCDEBUG=-g XCFLAGS='-DLUAJIT_ENABLE_LUA52COMPAT' CC=cc PREFIX=/usr/local/openresty/luajit
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3005,7 +3005,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3027,7 +3027,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3065,7 +3065,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-cjson-2.1.0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_CMODULE_DIR=/usr/local/openresty/lualib LUA_MODULE_DIR=/usr/local/openresty/lualib CJSON_CFLAGS="-g -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3093,7 +3093,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3111,7 +3111,7 @@ cd build
 export LUAJIT_LIB='/tmp/luajit/lib'
 export LUAJIT_INC='/tmp/luajit/include/luajit-2.1'
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3149,7 +3149,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=/tmp/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=/tmp/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=/tmp/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3177,7 +3177,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3199,7 +3199,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3238,7 +3238,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3267,7 +3267,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3289,7 +3289,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3328,7 +3328,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3357,7 +3357,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3379,7 +3379,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3418,7 +3418,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3447,7 +3447,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3469,7 +3469,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3508,7 +3508,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3537,7 +3537,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3559,7 +3559,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3598,7 +3598,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3626,7 +3626,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3648,7 +3648,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3687,7 +3687,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3715,7 +3715,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3737,7 +3737,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3776,7 +3776,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3805,7 +3805,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3827,7 +3827,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-debug \
   --with-cc-opt='-DNGX_LUA_USE_ASSERT -DNGX_LUA_ABORT_AT_PANIC -O2' \
@@ -3867,7 +3867,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CFLAGS="-g -O -Wall" CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3896,7 +3896,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -3918,7 +3918,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -3957,7 +3957,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -3986,7 +3986,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4008,7 +4008,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4047,7 +4047,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4076,7 +4076,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4098,7 +4098,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4137,7 +4137,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4166,7 +4166,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4188,7 +4188,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4227,7 +4227,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4256,7 +4256,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4278,7 +4278,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4317,7 +4317,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4346,7 +4346,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4368,7 +4368,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4407,7 +4407,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4435,7 +4435,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4457,7 +4457,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/luajit/lib'
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=./nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4498,7 +4498,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)./
@@ -4527,7 +4527,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)./bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)./
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)./
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)./site/lualib $(DESTDIR)./site/pod $(DESTDIR)./site/manifest
 	ln -sf ./nginx/sbin/nginx $(DESTDIR)./bin/openresty
 
@@ -4549,7 +4549,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/luajit/lib'
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=./nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4590,7 +4590,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)./
@@ -4619,7 +4619,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)./bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)./
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)./
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)./site/lualib $(DESTDIR)./site/pod $(DESTDIR)./site/manifest
 	ln -sf ./nginx/sbin/nginx $(DESTDIR)./bin/openresty
 
@@ -4641,7 +4641,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/luajit/lib'
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=./nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4682,7 +4682,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/luajit/include/luajit-2.1 LUA_LIB_DIR=./lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)./
@@ -4711,7 +4711,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)./bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)./
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)./
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)./site/lualib $(DESTDIR)./site/pod $(DESTDIR)./site/manifest
 	ln -sf ./nginx/sbin/nginx $(DESTDIR)./bin/openresty
 
@@ -4736,7 +4736,7 @@ cd src && install -m 0644 lua.h lualib.h lauxlib.h luaconf.h lua.hpp luajit.h $O
 export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root'
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/include/luajit-2.1'
 cd ..
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=. \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4775,7 +4775,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-cjson-2.1.0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/include/luajit-2.1 LUA_CMODULE_DIR=./lualib LUA_MODULE_DIR=./lualib CJSON_LDFLAGS="-shared -L$OPENRESTY_BUILD_DIR/luajit-root -llua51" CJSON_CFLAGS="-g -fpic" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/include/luajit-2.1 LUA_LIB_DIR=./lualib LDFLAGS="-shared -L$OPENRESTY_BUILD_DIR/luajit-root -llua51" CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/include/luajit-2.1 LUA_LIB_DIR=./lualib LDFLAGS="-shared -L$OPENRESTY_BUILD_DIR/luajit-root -llua51" CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)./
@@ -4802,7 +4802,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)./
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)./
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)./
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)./site/lualib $(DESTDIR)./site/pod $(DESTDIR)./site/manifest
 
 clean:
@@ -4823,7 +4823,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4862,7 +4862,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4891,7 +4891,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -4913,7 +4913,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -4952,7 +4952,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -4981,7 +4981,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5003,7 +5003,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5042,7 +5042,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5071,7 +5071,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5093,7 +5093,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5132,7 +5132,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5161,7 +5161,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5183,7 +5183,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5222,7 +5222,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5251,7 +5251,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5273,7 +5273,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5312,7 +5312,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5341,7 +5341,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5363,7 +5363,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5402,7 +5402,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5431,7 +5431,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /opt/blah/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5453,7 +5453,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5492,7 +5492,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5521,7 +5521,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf ../bin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5543,7 +5543,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5581,7 +5581,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5610,7 +5610,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5626,7 +5626,7 @@ platform: linux (linux)
 cp -rp bundle/ build
 cd build
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5657,7 +5657,7 @@ INSTALL := $OPENRESTY_BUILD_DIR/install
 .PHONY: all install clean
 
 all:
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5667,7 +5667,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5689,7 +5689,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5728,7 +5728,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5757,7 +5757,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 
@@ -5779,7 +5779,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5832,7 +5832,7 @@ export LUAJIT_LIB='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/l
 export LUAJIT_INC='$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1'
 cd ..
 patching the resty script with hard-coded nginx binary path...
-cd nginx-1.25.3
+cd nginx-1.25.4
 sh ./configure --prefix=/usr/local/openresty/nginx \
   --with-cc-opt='-O2' \
   --add-module=../ngx_devel_kit-0.3.3 \
@@ -5871,7 +5871,7 @@ all:
 	cd $OPENRESTY_BUILD_DIR/lua-resty-signal-0.03 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-redis-parser-0.13 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
 	cd $OPENRESTY_BUILD_DIR/lua-rds-parser-0.06 && $(MAKE) DESTDIR=$(DESTDIR) LUA_INCLUDE_DIR=$OPENRESTY_BUILD_DIR/luajit-root/usr/local/openresty/luajit/include/luajit-2.1 LUA_LIB_DIR=/usr/local/openresty/lualib CC=cc
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE)
 
 install: all
 	mkdir -p $(DESTDIR)/usr/local/openresty/
@@ -5900,7 +5900,7 @@ install: all
 	cd $OPENRESTY_BUILD_DIR/resty-cli-0.30 && $(INSTALL) bin/* $(DESTDIR)/usr/local/openresty/bin/
 	cp $OPENRESTY_BUILD_DIR/resty.index $(DESTDIR)/usr/local/openresty/
 	cp -r $OPENRESTY_BUILD_DIR/pod $(DESTDIR)/usr/local/openresty/
-	cd $OPENRESTY_BUILD_DIR/nginx-1.25.3 && $(MAKE) install DESTDIR=$(DESTDIR)
+	cd $OPENRESTY_BUILD_DIR/nginx-1.25.4 && $(MAKE) install DESTDIR=$(DESTDIR)
 	mkdir -p $(DESTDIR)/usr/local/openresty/site/lualib $(DESTDIR)/usr/local/openresty/site/pod $(DESTDIR)/usr/local/openresty/site/manifest
 	ln -sf /usr/local/openresty/nginx/sbin/nginx $(DESTDIR)/usr/local/openresty/bin/openresty
 

--- a/util/ver
+++ b/util/ver
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-main_ver=1.25.3
+main_ver=1.25.4
 minor_ver=1
 version=$main_ver.$minor_ver
 echo $version


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

#960 

This Pull Request aims to upgrade the embedded Nginx version within OpenResty from 1.25.3 to 1.25.4. As I am not very familiar with OpenResty, I have made an attempt to replace all instances of 1.25.3 with 1.25.4 of Nginx version. However, due to my limited knowledge, this patch has not been thoroughly tested.