### PR TITLE
patches: added initialize_quic_transport_id_variable.patch for nginx …

### DIFF
--- a/patches/nginx-1.27.0-initialize_quic_transport_id_variable.patch
+++ b/patches/nginx-1.27.0-initialize_quic_transport_id_variable.patch
@@ -1,0 +1,11 @@
+--- nginx-1.27.0/src/event/quic/ngx_event_quic_transport.c	2024-08-06 16:52:18.545250210 +0800
++++ nginx-1.27.0-patched/src/event/quic/ngx_event_quic_transport.c	2024-08-06 16:52:29.691035755 +0800
+@@ -1720,7 +1720,7 @@
+ ngx_quic_parse_transport_params(u_char *p, u_char *end, ngx_quic_tp_t *tp,
+     ngx_log_t *log)
+ {
+-    uint64_t   id, len;
++    uint64_t   id = 0, len;
+     ngx_int_t  rc;
+ 
+     while (p < end) {


### PR DESCRIPTION
…>= 1.27.0.

```
src/event/quic/ngx_event_quic_transport.c: In function ‘ngx_quic_parse_transport_params’:                                                                                                                          src/core/ngx_log.h:88:36: error: ‘id’ may be used uninitialized in this function [-Werror=maybe-uninitialized]                                                                                                        88 |     if ((log)->log_level >= level) ngx_log_error_core(level, log, __VA_ARGS__)                                                                                                                                   |                                    ^~~~~~~~~~~~~~~~~~                                                                                                                                                      src/event/quic/ngx_event_quic_transport.c:1723:16: note: ‘id’ was declared here
 1723 |     uint64_t   id, len;
      |                ^~
cc1: all warnings being treated as errors
```

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.