### PR TITLE
Disable pcre-jit for s390x in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,17 @@ env:
 
 install:
   - cpanm --sudo --notest Test::Nginx IPC::Run3 > build.log 2>&1 || (cat build.log && exit 1)
-  - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VER}/pcre-${PCRE_VER}.tar.gz; fi
+  - |
+    if [ "$TRAVIS_CPU_ARCH" != "s390x" ]; then
+      if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VER}/pcre-${PCRE_VER}.tar.gz; fi
+      tar zxf download-cache/pcre-$PCRE_VER.tar.gz
+      cd pcre-$PCRE_VER/
+      ./configure --prefix=$PCRE_PREFIX --enable-jit --enable-utf --enable-unicode-properties > build.log 2>&1 || (cat build.log && exit 1)
+      make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+      sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1)
+      cd ..
+    fi  
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz || wget -P download-cache https://www.openssl.org/source/old/${OPENSSL_VER//[a-z]/}/openssl-$OPENSSL_VER.tar.gz; fi
-  - tar zxf download-cache/pcre-$PCRE_VER.tar.gz
-  - cd pcre-$PCRE_VER/
-  - ./configure --prefix=$PCRE_PREFIX --enable-jit --enable-utf --enable-unicode-properties > build.log 2>&1 || (cat build.log && exit 1)
-  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
-  - sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1)
-  - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/
   - patch -p1 < ../patches/openssl-$OPENSSL_PATCH_VER-sess_set_get_cb_yield.patch


### PR DESCRIPTION
Hello,
PCRE's JIT does not support s390x, so `--enable-pcre-jit` cannot be used in building OpenResty.(https://github.com/openresty/openresty/issues/834#issuecomment-1145980116)
Since the recent commit - https://github.com/openresty/openresty/commit/476b640fbbece20051fd35458bd9e717c0c45a24 Travis CI is failing on s390x, hence skipping the PCRE installation steps for s390x in the `.travis.yml` file.