### PR TITLE
feature: Enable PCRE for s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,13 @@ env:
 install:
   - cpanm --sudo --notest Test::Nginx IPC::Run3 > build.log 2>&1 || (cat build.log && exit 1)
   - git clone https://github.com/openresty/test-nginx.git
-  - |
-    if [ "$TRAVIS_CPU_ARCH" != "s390x" ]; then
-      if [ ! -f download-cache/pcre2-$PCRE_VER.tar.gz ]; then wget -P download-cache https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE_VER}/pcre2-${PCRE_VER}.tar.gz; fi
-      tar zxf download-cache/pcre2-$PCRE_VER.tar.gz
-      cd pcre2-$PCRE_VER/
-      ./configure --prefix=$PCRE_PREFIX --enable-jit --enable-utf --enable-unicode-properties > build.log 2>&1 || (cat build.log && exit 1)
-      make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
-      sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1)
-      cd ..
-    fi  
+  - if [ ! -f download-cache/pcre2-$PCRE_VER.tar.gz ]; then wget -P download-cache https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${PCRE_VER}/pcre2-${PCRE_VER}.tar.gz; fi
+  - tar zxf download-cache/pcre2-$PCRE_VER.tar.gz
+  - cd pcre2-$PCRE_VER/
+  - ./configure --prefix=$PCRE_PREFIX --enable-jit --enable-utf --enable-unicode-properties > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..  
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VER}/openssl-${OPENSSL_VER}.tar.gz; fi
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/


### PR DESCRIPTION
Hello,
Since the Community is using PCRE 10.x series since [v1.27.1.2](https://github.com/openresty/openresty/commit/47dafb930e70f0103b14701395ad0d1a8a1dc4de) and its supported on s390x.

I've built the binary and executed the tests on s390x with latest changes, all the test cases have passed.
<img width="880" alt="pcre2-jit 10 45" src="https://github.com/user-attachments/assets/79fd922b-02eb-4275-8981-b7f67e6ce5ea" />

So re-enabling the PCRE build options.
This will also resolve the Issue - [#834 ]