### PR TITLE
bugfix: add HTTP/3 QUIC SSL Lua yield patch macro protection

### DIFF
--- a/patches/nginx/1.27.1/nginx-1.27.1-quic_ssl_lua_yield.patch
+++ b/patches/nginx/1.27.1/nginx-1.27.1-quic_ssl_lua_yield.patch
@@ -1,3 +1,16 @@
+diff --git a/src/core/ngx_config.h b/src/core/ngx_config.h
+index 1861be601..5a25172ed 100644
+--- a/src/core/ngx_config.h
++++ b/src/core/ngx_config.h
+@@ -18,6 +18,8 @@
+ #endif
+
+
++#define HAVE_QUIC_SSL_LUA_YIELD_PATCH  1
++
+ #if (NGX_FREEBSD)
+ #include <ngx_freebsd_config.h>
+
 diff --git a/src/event/quic/ngx_event_quic.c b/src/event/quic/ngx_event_quic.c
 index c03b1d003..ffb21490c 100644
 --- a/src/event/quic/ngx_event_quic.c


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
