### PR TITLE
bugfix: Create HTML directory if it does not exist

### DIFF
--- a/util/mirror-tarballs
+++ b/util/mirror-tarballs
@@ -576,6 +576,8 @@ if [ "$answer" = "Y" ]; then
     patch -p1 < $root/patches/nginx/$main_ver/nginx-$main_ver-quic_ssl_lua_yield.patch || exit 1
 fi
 
+mkdir -p html || exit 1
+
 cp $root/html/index.html html/ || exit 1
 cp $root/html/50x.html html/ || exit 1
 


### PR DESCRIPTION
mirror-tarballs script breaks on a fresh clone of the repo due to the missing html dir. Simply creating this directory allows the script to complete successfully.

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
