### PR TITLE
fixes: Ensure resty.index is generated for restydoc (resolve make install error)

### DIFF
--- a/util/configure
+++ b/util/configure
@@ -425,6 +425,12 @@ shell $cmd, $dry_run;
 push @make_cmds, "cd $root_dir/build/$ngx_dir && "
     . "\$(MAKE)";
 
+    # Generate resty.index for restydoc
+    push @make_cmds,
+        "cd $root_dir/bundle/resty-cli-0.32 && "
+        . "perl -I./bin bin/restydoc-index --outdir ../build $root_dir/bundle/lua-resty-core-0.1.32R1";
+
+
 push @make_install_cmds, "cd $root_dir/build/$ngx_dir && "
     . "\$(MAKE) install DESTDIR=\$(DESTDIR)";
 


### PR DESCRIPTION
## fixes : Ensure resty.index is generated for restydoc (resolve make install error)

### Problem
When running `make install`, the build fails with:
```
cp /usr/local/src/openresty-or-1.29.4/openresty-1.29.4.1/build/resty.index /usr/local/openresty/
cp: cannot stat '/usr/local/src/openresty-or-1.29.4/openresty-1.29.4.1/build/resty.index': No such file or directory
make: *** [Makefile:38: install] Error 1
```