### PR TITLE
bugfix: limit HTTP/2 subrequest error wakeup

### DIFF
--- a/patches/nginx/1.27.1/nginx-1.27.1-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.27.1/nginx-1.27.1-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 9593b7f..dbc23ff 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2560,8 +2560,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2560,8 +2560,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.29.4/nginx-1.29.4-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.4/nginx-1.29.4-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.29.8/nginx-1.29.8-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.8/nginx-1.29.8-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.31.0/nginx-1.31.0-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.31.0/nginx-1.31.0-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }

--- a/patches/nginx/1.31.1/nginx-1.31.1-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.31.1/nginx-1.31.1-http2_subreq_error_wakeup.patch
@@ -2,12 +2,15 @@ diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
 index 16d79c4..760e0e5 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,18 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version < NGX_HTTP_VERSION_20
++            || r == r->main
++            || r->post_subrequest == NULL)
++        {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }


### PR DESCRIPTION
I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.

## Summary

This narrows the `http2_subreq_error_wakeup` nginx patches so HTTP/2 subrequests only skip `ngx_http_terminate_request()` when they have a `post_subrequest` callback.

PR #1083 needs that fallthrough for callback-driven subrequests such as `ngx.location.capture`, where the parent request must be woken instead of having its posted requests cleared by termination. Native nginx subrequests without a callback, such as slice range subrequests, do not need that wakeup path.

## Root Cause

The current guard only checks for HTTP/2 subrequests:

```c
if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
    ngx_http_terminate_request(r, rc);
    return;
}
```

That also catches native subrequests with `r->post_subrequest == NULL`. With HTTP/2 + `slice` + `proxy_cache`, a stalled or aborting client can finalize a slice subrequest with `NGX_HTTP_REQUEST_TIME_OUT`. Instead of terminating, it falls through to `ngx_http_special_response_handler()`, tries to send a 408 header after the 200 header was already sent, and floods the error log with `header already sent`.

## Changes

All existing `nginx-*-http2_subreq_error_wakeup.patch` files now terminate HTTP/2 subrequest errors when the subrequest has no callback:

```c
if (r->http_version < NGX_HTTP_VERSION_20
    || r == r->main
    || r->post_subrequest == NULL)
{
    ngx_http_terminate_request(r, rc);
    return;
}
```

This keeps the callback wakeup behavior from PR #1083 while excluding native subrequests such as slice.



Test case: https://github.com/openresty/lua-nginx-module/pull/2507