### PR TITLE
bugfix: restrict HTTP/2 subrequest error wakeup to Lua subrequests

### DIFF
--- a/patches/nginx/1.27.1/nginx-1.27.1-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.27.1/nginx-1.27.1-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 9593b7f..dbc23ff 100644
+index 3cca57cf5..7c1b7a512 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2560,8 +2560,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2537,8 +2537,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 9593b7f..dbc23ff 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 65c8333f8..077491f01 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -541,6 +543,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
@@ -32,7 +32,7 @@ index ad11f147f..b0c5fd262 100644
  #define NGX_HTTP_MAX_URI_CHANGES           10
  #define NGX_HTTP_MAX_SUBREQUESTS           50
  
-+#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
 +
  /* must be 2^n */
  #define NGX_HTTP_LC_HEADER_LEN             32
@@ -41,7 +41,7 @@ index ad11f147f..b0c5fd262 100644
      unsigned                          internal:1;
      unsigned                          error_page:1;
      unsigned                          filter_finalize:1;
-+    unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
      unsigned                          post_action:1;
      unsigned                          request_complete:1;
      unsigned                          request_output:1;

--- a/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.2/nginx-1.29.2-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index 16d79c490..2c2566c63 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2559,8 +2559,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index ad11f147f..b0c5fd262 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -544,6 +546,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          filter_finalize:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.29.4/nginx-1.29.4-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.4/nginx-1.29.4-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index 41c1cda04..507decb36 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2675,8 +2675,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 1b012f810..bbd36d728 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -546,6 +548,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index 41c1cda04..507decb36 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2675,8 +2675,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 1b012f810..2f358d1c9 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -546,6 +548,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.5/nginx-1.29.5-http2_subreq_error_wakeup.patch
@@ -41,7 +41,7 @@ index 1b012f810..2f358d1c9 100644
      unsigned                          internal:1;
      unsigned                          error_page:1;
      unsigned                          filter_finalize:1;
-+    unsigned                          lua_subrequest:1
++    unsigned                          lua_subrequest:1;
      unsigned                          post_action:1;
      unsigned                          request_complete:1;
      unsigned                          request_output:1;

--- a/patches/nginx/1.29.8/nginx-1.29.8-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.29.8/nginx-1.29.8-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index a9573a620..c2c0c6d78 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2688,8 +2688,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 48eb43eb0..9751e0bce 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -550,6 +552,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.31.0/nginx-1.31.0-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.31.0/nginx-1.31.0-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index a5cd44dcc..634dd225b 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2708,8 +2708,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 6d18cc3c6..df57a021d 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -550,6 +552,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;

--- a/patches/nginx/1.31.1/nginx-1.31.1-http2_subreq_error_wakeup.patch
+++ b/patches/nginx/1.31.1/nginx-1.31.1-http2_subreq_error_wakeup.patch
@@ -1,13 +1,19 @@
 diff --git a/src/http/ngx_http_request.c b/src/http/ngx_http_request.c
-index 16d79c4..760e0e5 100644
+index a5cd44dcc..634dd225b 100644
 --- a/src/http/ngx_http_request.c
 +++ b/src/http/ngx_http_request.c
-@@ -2559,8 +2559,15 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
+@@ -2708,8 +2708,21 @@ ngx_http_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
              return;
          }
  
 +#if (NGX_HTTP_V2)
-+        if (r->http_version < NGX_HTTP_VERSION_20 || r == r->main) {
++        if (r->http_version >= NGX_HTTP_VERSION_20
++            && r != r->main
++            && r->post_subrequest
++            && r->lua_subrequest)
++        {
++            /* fall through to normal subrequest finalization */
++        } else {
 +            ngx_http_terminate_request(r, rc);
 +            return;
 +        }
@@ -18,3 +24,24 @@ index 16d79c4..760e0e5 100644
      }
  
      if (rc >= NGX_HTTP_SPECIAL_RESPONSE
+diff --git a/src/http/ngx_http_request.h b/src/http/ngx_http_request.h
+index 6d18cc3c6..df57a021d 100644
+--- a/src/http/ngx_http_request.h
++++ b/src/http/ngx_http_request.h
+@@ -12,6 +12,8 @@
+ #define NGX_HTTP_MAX_URI_CHANGES           10
+ #define NGX_HTTP_MAX_SUBREQUESTS           50
+ 
++#define NGX_HTTP_OPENRESTY_LUA_SUBREQUEST  1
++
+ /* must be 2^n */
+ #define NGX_HTTP_LC_HEADER_LEN             32
+ 
+@@ -550,6 +552,7 @@ struct ngx_http_request_s {
+     unsigned                          internal:1;
+     unsigned                          error_page:1;
+     unsigned                          filter_finalize:1;
++    unsigned                          lua_subrequest:1;
+     unsigned                          post_action:1;
+     unsigned                          request_complete:1;
+     unsigned                          request_output:1;


### PR DESCRIPTION
The previous nginx patch allowed all HTTP/2 subrequests to fall through normal subrequest finalization on error. This also affected native nginx subrequests such as slice, which do not have a Lua parent coroutine to wake up and can hit "header already sent".

Gate the wakeup path on the Lua subrequest flag set by lua-nginx-module, so the patch preserves the original Lua subrequest fix without changing other nginx subrequest types.

sister PR: https://github.com/openresty/lua-nginx-module/pull/2508

fix: https://github.com/openresty/openresty/issues/1131

I hereby granted the copyright of the changes in this pull request
to the authors of this openresty project.
